### PR TITLE
Fix: Bump libxml2 to version 2.13.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 # CMD ["nginx", "-g", "daemon off;"]
 
-RUN apk add --no-cache shadow && \
+RUN apk add --no-cache libxml2=2.13.9-r0 shadow && \
     useradd -U -u 1000 appuser && \
     chown -R 1000:1000 /usr/share/nginx/html /entrypoint.sh
 USER 1000


### PR DESCRIPTION
Pinning `libxml2` to version `2.13.9-r0` to fix following 5 CVEs:
`CVE-2025-49794` `CVE-2025-49796` `CVE-2025-49795` `CVE-2025-6021` `CVE-2025-6170`

Steps to reproduce:

1. Build Docker image:

```bash
docker build -t inspector-app .
```

2. Scan with `trivy`:

```bash
trivy image inspector-app
```
Result should be something like the following:
```bash
Report Summary

┌───────────────────────────────┬────────┬─────────────────┬─────────┐
│            Target             │  Type  │ Vulnerabilities │ Secrets │
├───────────────────────────────┼────────┼─────────────────┼─────────┤
│ inspector-app (alpine 3.21.5) │ alpine │        5        │    -    │
└───────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


inspector-app (alpine 3.21.5)

Total: 5 (UNKNOWN: 0, LOW: 1, MEDIUM: 0, HIGH: 2, CRITICAL: 2)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libxml2 │ CVE-2025-49794 │ CRITICAL │ fixed  │ 2.13.4-r6         │ 2.13.9-r0     │ libxml: Heap use after free (UAF) leads to Denial of service │
│         │                │          │        │                   │               │ (DoS)...                                                     │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-49794                   │
│         ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-49796 │          │        │                   │               │ libxml: Type confusion leads to Denial of service (DoS)      │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-49796                   │
│         ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-49795 │ HIGH     │        │                   │               │ libxml: Null pointer dereference leads to Denial of service  │
│         │                │          │        │                   │               │ (DoS)                                                        │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-49795                   │
│         ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-6021  │          │        │                   │               │ libxml2: Integer Overflow in xmlBuildQName() Leads to Stack  │
│         │                │          │        │                   │               │ Buffer Overflow in libxml2...                                │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-6021                    │
│         ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2025-6170  │ LOW      │        │                   │               │ libxml2: Stack Buffer Overflow in xmllint Interactive Shell  │
│         │                │          │        │                   │               │ Command Handling                                             │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-6170                    │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

**THIS IS A TEMPORARY FIX until the base image gets patched.**