### PR TITLE
feat: TX Builder for multi-clause transactions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,9 @@
 <body class="has-navbar-fixed-top">
     <Navbar class="is-fixed-top" />
     <div class="router-view">
-        <router-view></router-view>
+        <keep-alive include="TxBuilder">
+            <router-view></router-view>
+        </keep-alive>
     </div>
 </body>
 </template>

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -3,6 +3,7 @@ import Router from 'vue-router'
 import NotSupport from './views/NotSupport.vue'
 import Contracts from './views/Contracts.vue'
 import Deploy from './views/DeployContract.vue'
+import TxBuilder from './views/TxBuilder.vue'
 import ContractDetail from './views/ContractDetail.vue'
 import FilterView from './views/FilterView.vue'
 import FilterMgt from './views/FilterMgt.vue'
@@ -32,6 +33,11 @@ const router = new Router({
       name: 'deploy',
       component: Deploy,
       path: '/deploy'
+    },
+    {
+      name: 'tx_builder',
+      component: TxBuilder,
+      path: '/tx-builder'
     },
     {
       name: 'contract_detail',

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -125,6 +125,7 @@ import { getCustomNetworks, getNetworkById } from '../services/network-service'
 export default class Navbar extends Vue {
     private routes = [
         { name: 'contracts', text: 'Contracts' },
+        { name: 'tx_builder', text: 'TX Builder' },
         { name: 'deploy', text: 'Deploy' }
     ]
 

--- a/src/components/TxBuilder/ClauseEditor.vue
+++ b/src/components/TxBuilder/ClauseEditor.vue
@@ -1,0 +1,552 @@
+<template>
+    <div class="clause-editor">
+        <!-- Section 1: Contract -->
+        <section class="editor-section">
+            <div class="section-label">Contract</div>
+            <div v-if="clause.contractAddress" class="contract-summary">
+                <div class="contract-summary__main">
+                    <div class="contract-summary__name">{{ clause.contractName || 'Contract' }}</div>
+                    <div class="contract-summary__addr is-family-monospace">{{ clause.contractAddress }}</div>
+                </div>
+                <button type="button" class="button is-small is-light" @click="changeContract">
+                    <b-icon icon="exchange-alt" size="is-small"></b-icon>
+                    <span>Change</span>
+                </button>
+            </div>
+            <ContractPicker v-else :network="network" @pick="onPickContract" />
+        </section>
+
+        <!-- Section 2: Function -->
+        <section v-if="clause.contractAddress" class="editor-section">
+            <div class="section-label">Function</div>
+            <div v-if="clause.selectedFunction" class="function-summary">
+                <div class="function-summary__main">
+                    <span class="function-summary__name is-family-monospace">{{ clause.selectedFunction.name }}</span>
+                    <span class="function-summary__sig">
+                        ({{ inputTypes(clause.selectedFunction) }})
+                    </span>
+                    <span class="mutability-pill" :class="mutabilityClass(clause.selectedFunction)">
+                        {{ clause.selectedFunction.stateMutability || (clause.selectedFunction.constant ? 'view' : 'nonpayable') }}
+                    </span>
+                </div>
+                <button type="button" class="icon-btn" title="Clear" @click="clearFunction">
+                    <b-icon icon="times" size="is-small"></b-icon>
+                </button>
+            </div>
+            <div v-else>
+                <b-input
+                    v-model="fnSearch"
+                    placeholder="Filter functions"
+                    icon="search"
+                    size="is-small"
+                ></b-input>
+                <div v-if="filteredFunctions.length" class="function-list">
+                    <div
+                        v-for="fn in filteredFunctions"
+                        :key="fn.name + ':' + (fn.inputs || []).map(i => i.type).join(',')"
+                        class="function-row"
+                        @click="onSelectFunction(fn)"
+                    >
+                        <span class="function-row__name is-family-monospace">{{ fn.name }}</span>
+                        <span class="function-row__sig">({{ inputTypes(fn) }})</span>
+                        <span class="mutability-pill" :class="mutabilityClass(fn)">
+                            {{ fn.stateMutability || (fn.constant ? 'view' : 'nonpayable') }}
+                        </span>
+                    </div>
+                </div>
+                <div v-else class="no-fns has-text-grey-light">
+                    No state-changing functions in this ABI. View/pure functions can't be used in a transaction.
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 3: Parameters -->
+        <section v-if="clause.selectedFunction" class="editor-section">
+            <div class="section-label">
+                Parameters
+                <span class="section-sublabel" v-if="clause.selectedFunction.inputs && clause.selectedFunction.inputs.length">
+                    · {{ clause.selectedFunction.inputs.length }}
+                </span>
+            </div>
+            <div v-if="!clause.selectedFunction.inputs || !clause.selectedFunction.inputs.length" class="no-params has-text-grey-light">
+                This function takes no parameters.
+            </div>
+            <div v-else class="params-stack">
+                <div
+                    v-for="(input, i) in clause.selectedFunction.inputs"
+                    :key="i"
+                    class="param-row"
+                >
+                    <div class="param-row__header">
+                        <span class="param-row__name">{{ input.name || ('arg' + i) }}</span>
+                        <span class="param-row__type is-family-monospace">{{ input.type }}</span>
+                    </div>
+                    <RoleSelector
+                        v-if="isRoleInput(input)"
+                        :contractAddress="clause.contractAddress"
+                        :abi="clause.abi"
+                        :network="network"
+                        :value="clause.params[i] || ''"
+                        @input="onParam(i, $event)"
+                    />
+                    <ParamInput
+                        v-else
+                        :input="input"
+                        :value="clause.params[i]"
+                        @input="onParam(i, $event)"
+                    />
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 4: VET value (only when payable) -->
+        <section v-if="clause.selectedFunction && isPayable" class="editor-section">
+            <div class="section-label">VET value</div>
+            <b-field grouped>
+                <b-input
+                    custom-class="is-family-monospace has-text-weight-semibold"
+                    :placeholder="valueUnit === 'vet' ? 'number (vet)' : 'number (wei)'"
+                    v-model.trim="displayValue"
+                    expanded
+                ></b-input>
+                <p class="control">
+                    <div class="buttons has-addons unit-toggle-group">
+                        <button
+                            type="button"
+                            class="button unit-toggle-btn"
+                            :class="{ 'is-active': valueUnit === 'vet' }"
+                            @click="valueUnit = 'vet'"
+                        >VET</button>
+                        <button
+                            type="button"
+                            class="button unit-toggle-btn"
+                            :class="{ 'is-active': valueUnit === 'wei' }"
+                            @click="valueUnit = 'wei'"
+                        >WEI</button>
+                    </div>
+                </p>
+            </b-field>
+        </section>
+
+        <!-- Section 5: Note -->
+        <section v-if="clause.selectedFunction" class="editor-section">
+            <div class="section-label">Note (optional)</div>
+            <b-input
+                :value="clause.note || ''"
+                @input="updateNote"
+                type="textarea"
+                rows="2"
+                placeholder="Per-clause comment (used as the clause's comment)"
+            ></b-input>
+        </section>
+
+        <!-- Section 6: Encoded preview -->
+        <section v-if="encoded" class="editor-section">
+            <div class="section-label">Encoded calldata</div>
+            <pre class="calldata-block">{{ encoded.isValid ? encoded.data : (encoded.error || '—') }}</pre>
+            <div class="calldata-bytes" v-if="encoded.isValid">
+                {{ ((encoded.data.length - 2) / 2) }} bytes
+            </div>
+        </section>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { Entities } from '../../database'
+import ContractPicker from './ContractPicker.vue'
+import ParamInput from './ParamInput.vue'
+import RoleSelector from './RoleSelector.vue'
+import { isRoleParam } from '../../utils/role-discovery'
+
+interface EncodedClause {
+    isValid: boolean
+    data: string
+    error?: string
+}
+
+@Component({
+    components: { ContractPicker, ParamInput, RoleSelector }
+})
+export default class ClauseEditor extends Vue {
+    @Prop({ required: true }) clause!: Entities.TxBuilderClause
+    @Prop({ required: true }) network!: string
+    @Prop({ default: null }) encoded!: EncodedClause | null
+
+    private fnSearch: string = ''
+    private valueUnit: 'vet' | 'wei' = 'vet'
+
+    get isPayable(): boolean {
+        const fn = this.clause.selectedFunction
+        if (!fn) return false
+        return !!fn.payable || fn.stateMutability === 'payable'
+    }
+
+    get functions(): ABI.FunctionItem[] {
+        const abi = this.clause.abi || []
+        return abi
+            .filter((item: any) => {
+                if (!item || item.type !== 'function') return false
+                const m = item.stateMutability || (item.constant ? 'view' : 'nonpayable')
+                return m !== 'view' && m !== 'pure'
+            })
+            .map((item: any) => ({
+                ...item,
+                inputs: item.inputs || [],
+                outputs: item.outputs || [],
+                stateMutability: item.stateMutability || 'nonpayable',
+                payable: !!item.payable
+            }))
+    }
+
+    private isRoleInput(input: ABI.InputItem): boolean {
+        return isRoleParam(input)
+    }
+
+    get filteredFunctions(): ABI.FunctionItem[] {
+        const q = this.fnSearch.trim().toLowerCase()
+        if (!q) return this.functions
+        return this.functions.filter(fn => fn.name.toLowerCase().includes(q))
+    }
+
+    get displayValue(): string {
+        if (!this.clause.value) return ''
+        try {
+            const bn = BN(this.clause.value)
+            if (bn.isNaN() || !bn.isFinite()) return this.clause.value
+            if (this.valueUnit === 'wei') {
+                return bn.multipliedBy('1000000000000000000').toFixed(0, BN.ROUND_DOWN)
+            }
+            return bn.toFixed(18, BN.ROUND_DOWN).replace(/\.?0+$/, '') || '0'
+        } catch {
+            return this.clause.value || ''
+        }
+    }
+
+    set displayValue(val: string) {
+        if (!val) {
+            this.update({ value: null })
+            return
+        }
+        if (this.valueUnit === 'wei') {
+            if (!/^\d+$/.test(val)) return
+            try {
+                const bn = BN(val)
+                if (bn.isNaN() || !bn.isFinite()) return
+                const result = bn.dividedBy('1000000000000000000').toFixed(18, BN.ROUND_DOWN)
+                this.update({ value: result.replace(/\.?0+$/, '') || '0' })
+            } catch {
+                /* ignore */
+            }
+        } else {
+            if (!/^\d*\.?\d*$/.test(val)) return
+            this.update({ value: val })
+        }
+    }
+
+    private inputTypes(fn: ABI.FunctionItem): string {
+        return (fn.inputs || []).map(i => i.type).join(', ')
+    }
+
+    private mutabilityClass(fn: ABI.FunctionItem): string {
+        const m = fn.stateMutability || (fn.constant ? 'view' : 'nonpayable')
+        if (m === 'view' || m === 'pure') return 'is-view'
+        if (m === 'payable') return 'is-payable'
+        return 'is-write'
+    }
+
+    private onPickContract(payload: { address: string; name: string; abi: any[] }) {
+        this.update({
+            contractAddress: payload.address,
+            contractName: payload.name,
+            abi: payload.abi,
+            selectedFunction: null,
+            params: [],
+            value: null
+        })
+    }
+
+    private changeContract() {
+        this.update({
+            contractAddress: '',
+            contractName: '',
+            abi: [],
+            selectedFunction: null,
+            params: [],
+            value: null
+        })
+    }
+
+    private onSelectFunction(fn: ABI.FunctionItem) {
+        const params = new Array((fn.inputs || []).length).fill('')
+        this.update({ selectedFunction: fn, params })
+        this.fnSearch = ''
+    }
+
+    private clearFunction() {
+        this.update({ selectedFunction: null, params: [], value: null })
+    }
+
+    private onParam(index: number, val: any) {
+        const params = [...this.clause.params]
+        params[index] = val === undefined || val === null ? '' : String(val)
+        this.update({ params })
+    }
+
+    private updateNote(val: string) {
+        this.update({ note: val })
+    }
+
+    private update(patch: Partial<Entities.TxBuilderClause>) {
+        this.$emit('update', { id: this.clause.id, patch })
+    }
+
+    @Watch('clause.id')
+    private onClauseChange() {
+        this.fnSearch = ''
+        this.valueUnit = 'vet'
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.clause-editor {
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    height: 100%;
+}
+
+.editor-section {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+}
+.section-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-light);
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+}
+.section-sublabel {
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 400;
+}
+
+.contract-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+.contract-summary__name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+}
+.contract-summary__addr {
+    font-size: 0.8rem;
+    color: var(--text-color-light);
+    word-break: break-all;
+}
+
+.function-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+.function-summary__main {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    flex: 1;
+}
+.function-summary__name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+}
+.function-summary__sig {
+    color: var(--text-color-light);
+    font-size: 0.85rem;
+}
+
+.function-list {
+    max-height: 280px;
+    overflow-y: auto;
+    margin-top: 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+}
+.function-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    border-bottom: 1px solid var(--border-color-light);
+}
+.function-row:last-child {
+    border-bottom: none;
+}
+.function-row:hover {
+    background: var(--body-background-alt);
+}
+.function-row__name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+    flex-shrink: 0;
+}
+.function-row__sig {
+    flex: 1;
+    color: var(--text-color-light);
+    font-size: 0.85rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mutability-pill {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 8px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.mutability-pill.is-view {
+    background: rgba(50, 175, 50, 0.12);
+    color: #228822;
+}
+.mutability-pill.is-payable {
+    background: rgba(255, 165, 0, 0.12);
+    color: #cc7700;
+}
+.mutability-pill.is-write {
+    background: rgba(50, 115, 220, 0.12);
+    color: #3273dc;
+}
+
+.no-fns, .no-params {
+    padding: 0.5rem 0;
+    font-size: 0.85rem;
+}
+
+.params-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.param-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.param-row__header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+.param-row__name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+    font-size: 0.85rem;
+}
+.param-row__type {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    background: var(--body-background-alt);
+    padding: 0.05rem 0.4rem;
+    border-radius: 4px;
+}
+
+.calldata-block {
+    background: var(--body-background-alt);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.75rem;
+    font-size: 0.75rem;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 200px;
+    overflow-y: auto;
+}
+.calldata-bytes {
+    margin-top: 0.25rem;
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+}
+
+.icon-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-color-light);
+    cursor: pointer;
+    padding: 0.15rem 0.3rem;
+    border-radius: 4px;
+}
+.icon-btn:hover {
+    color: var(--text-color-strong);
+    background: var(--body-background-alt);
+}
+
+.unit-toggle-group {
+    margin: 0;
+}
+.unit-toggle-btn {
+    min-width: 50px;
+    font-weight: 600;
+    height: 2.5em;
+    background-color: #f5f5f5;
+    border-color: #dbdbdb;
+    color: #363636;
+}
+.unit-toggle-btn:hover {
+    background-color: #e8e8e8;
+}
+.unit-toggle-btn.is-active {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    color: #ffffff;
+}
+
+[data-theme="dark"] {
+    .calldata-block {
+        background: #101010;
+        color: #e8e8e8;
+    }
+    .mutability-pill.is-view {
+        background: rgba(80, 220, 80, 0.18);
+        color: #6be86b;
+    }
+    .mutability-pill.is-payable {
+        background: rgba(255, 180, 30, 0.18);
+        color: #ffd766;
+    }
+    .mutability-pill.is-write {
+        background: rgba(107, 182, 255, 0.18);
+        color: #6bb6ff;
+    }
+    .unit-toggle-btn {
+        background-color: #2a2a2a;
+        border-color: #404040;
+        color: #e8e8e8;
+    }
+    .unit-toggle-btn:hover {
+        background-color: #353535;
+    }
+    .unit-toggle-btn.is-active {
+        background-color: var(--primary-color);
+        border-color: var(--primary-color);
+        color: #ffffff;
+    }
+}
+</style>

--- a/src/components/TxBuilder/ClauseList.vue
+++ b/src/components/TxBuilder/ClauseList.vue
@@ -1,0 +1,273 @@
+<template>
+    <div class="clause-list">
+        <div class="clause-list__header">
+            <span class="clause-list__title">Clauses</span>
+            <span class="clause-list__count">{{ clauses.length }}</span>
+        </div>
+
+        <div
+            v-for="(clause, index) in clauses"
+            :key="clause.id"
+            class="clause-card"
+            :class="{ 'is-active': clause.id === activeId, 'is-invalid': encoded[index] && !encoded[index].isValid }"
+            @click="$emit('select', clause.id)"
+        >
+            <div class="clause-card__index">{{ index + 1 }}</div>
+            <div class="clause-card__body">
+                <div class="clause-card__title">
+                    {{ clauseTitle(clause) }}
+                </div>
+                <div class="clause-card__sub">
+                    <span v-if="clause.contractName" class="contract-tag">{{ clause.contractName }}</span>
+                    <span v-if="clause.contractAddress" class="addr is-family-monospace">
+                        {{ clause.contractAddress | addr }}
+                    </span>
+                </div>
+            </div>
+            <div class="clause-card__status">
+                <b-icon
+                    v-if="encoded[index] && encoded[index].isValid"
+                    icon="check-circle"
+                    size="is-small"
+                    class="has-text-success"
+                ></b-icon>
+                <span v-else class="dot dot--pending" :title="encoded[index] && encoded[index].error || 'Incomplete'"></span>
+            </div>
+            <div class="clause-card__actions">
+                <button
+                    type="button"
+                    class="icon-btn"
+                    title="Move up"
+                    :disabled="index === 0"
+                    @click.stop="$emit('move', { id: clause.id, delta: -1 })"
+                >
+                    <b-icon icon="arrow-up" size="is-small"></b-icon>
+                </button>
+                <button
+                    type="button"
+                    class="icon-btn"
+                    title="Move down"
+                    :disabled="index === clauses.length - 1"
+                    @click.stop="$emit('move', { id: clause.id, delta: 1 })"
+                >
+                    <b-icon icon="arrow-down" size="is-small"></b-icon>
+                </button>
+                <button
+                    type="button"
+                    class="icon-btn icon-btn--danger"
+                    title="Remove"
+                    @click.stop="$emit('remove', clause.id)"
+                >
+                    <b-icon icon="times" size="is-small"></b-icon>
+                </button>
+            </div>
+        </div>
+
+        <button type="button" class="add-clause-btn" @click="$emit('add')">
+            <b-icon icon="plus" size="is-small"></b-icon>
+            <span>Add clause</span>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Entities } from '../../database'
+
+interface EncodedClause {
+    isValid: boolean
+    error?: string
+}
+
+@Component
+export default class ClauseList extends Vue {
+    @Prop({ required: true }) clauses!: Entities.TxBuilderClause[]
+    @Prop({ default: null }) activeId!: string | null
+    @Prop({ required: true }) encoded!: EncodedClause[]
+
+    private clauseTitle(c: Entities.TxBuilderClause): string {
+        if (!c.contractAddress) return 'Pick a contract…'
+        if (!c.selectedFunction) return 'Pick a function…'
+        return this.humanize(c.selectedFunction.name)
+    }
+
+    private humanize(name: string): string {
+        if (!name) return ''
+        const split = name.replace(/([A-Z])/g, ' $1').trim().toLowerCase()
+        return split.charAt(0).toUpperCase() + split.slice(1)
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.clause-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.clause-list__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+.clause-list__title {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-light);
+    font-weight: 600;
+}
+.clause-list__count {
+    font-size: 0.75rem;
+    color: var(--text-color-light);
+    background: var(--body-background-alt);
+    padding: 0.1rem 0.5rem;
+    border-radius: 8px;
+}
+
+.clause-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--card-background);
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s;
+    position: relative;
+}
+.clause-card:hover {
+    border-color: var(--primary-color);
+}
+.clause-card.is-active {
+    border-color: var(--primary-color);
+    background: rgba(50, 115, 220, 0.04);
+}
+.clause-card.is-invalid {
+    border-left: 3px solid #ffb020;
+}
+
+.clause-card__index {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: var(--body-background-alt);
+    color: var(--text-color);
+    font-size: 0.75rem;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+.clause-card.is-active .clause-card__index {
+    background: var(--primary-color);
+    color: white;
+}
+
+.clause-card__body {
+    flex: 1;
+    min-width: 0;
+}
+.clause-card__title {
+    font-size: 0.9rem;
+    color: var(--text-color-strong);
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.clause-card__sub {
+    margin-top: 0.2rem;
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+.contract-tag {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    background: var(--body-background-alt);
+    padding: 0.05rem 0.4rem;
+    border-radius: 4px;
+}
+.addr {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+}
+
+.clause-card__status {
+    align-self: center;
+}
+.dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+.dot--pending {
+    background: #ffb020;
+}
+
+.clause-card__actions {
+    position: absolute;
+    top: 0.4rem;
+    right: 0.4rem;
+    display: none;
+    gap: 0.15rem;
+}
+.clause-card:hover .clause-card__actions,
+.clause-card.is-active .clause-card__actions {
+    display: flex;
+}
+.icon-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-color-light);
+    cursor: pointer;
+    padding: 0.15rem;
+    border-radius: 4px;
+}
+.icon-btn:hover:not(:disabled) {
+    color: var(--text-color-strong);
+    background: var(--body-background-alt);
+}
+.icon-btn:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+.icon-btn--danger:hover:not(:disabled) {
+    color: #ff3860;
+}
+
+.add-clause-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.6rem;
+    border: 1px dashed var(--border-color);
+    background: transparent;
+    border-radius: 8px;
+    color: var(--text-color-light);
+    cursor: pointer;
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+}
+.add-clause-btn:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+[data-theme="dark"] {
+    .clause-card.is-active {
+        background: rgba(74, 158, 255, 0.08);
+    }
+}
+</style>

--- a/src/components/TxBuilder/ContractPicker.vue
+++ b/src/components/TxBuilder/ContractPicker.vue
@@ -1,0 +1,311 @@
+<template>
+    <div class="contract-picker">
+        <!-- Tabs: Library / Manual -->
+        <div class="picker-tabs">
+            <button
+                type="button"
+                class="picker-tab"
+                :class="{ 'is-active': mode === 'library' }"
+                @click="mode = 'library'"
+            >Library</button>
+            <button
+                type="button"
+                class="picker-tab"
+                :class="{ 'is-active': mode === 'manual' }"
+                @click="mode = 'manual'"
+            >Enter manually</button>
+        </div>
+
+        <!-- Library: autocomplete over user contracts + built-ins -->
+        <div v-if="mode === 'library'" class="picker-body">
+            <b-autocomplete
+                v-model="search"
+                :data="filtered"
+                field="name"
+                :loading="loading"
+                open-on-focus
+                clearable
+                placeholder="Search contracts by name or address"
+                @select="onSelect"
+            >
+                <template #default="{ option }">
+                    <div class="picker-row">
+                        <div class="picker-row__name">
+                            <span class="has-text-weight-semibold">{{ option.name }}</span>
+                            <span v-if="option.source" class="picker-row__badge" :class="badgeClass(option.source)">
+                                {{ option.source }}
+                            </span>
+                        </div>
+                        <div v-if="option.address" class="picker-row__addr is-family-monospace">
+                            {{ option.address | addr }}
+                        </div>
+                        <div v-else class="picker-row__addr has-text-grey-light">
+                            no address for this network
+                        </div>
+                    </div>
+                </template>
+                <template #empty>
+                    <div class="has-text-grey py-2 px-3">No matches. Try "Enter manually".</div>
+                </template>
+            </b-autocomplete>
+        </div>
+
+        <!-- Manual entry: name + address + ABI textarea -->
+        <div v-else class="picker-body">
+            <b-field
+                :type="formErrors.name ? 'is-danger' : ''"
+                :message="formErrors.name"
+                label="Name"
+            >
+                <b-input v-model="manual.name" placeholder="My Contract"></b-input>
+            </b-field>
+            <b-field
+                :type="formErrors.address ? 'is-danger' : ''"
+                :message="formErrors.address"
+                label="Address"
+            >
+                <b-input
+                    v-model="manual.address"
+                    custom-class="is-family-monospace has-text-weight-semibold"
+                    placeholder="0x..."
+                ></b-input>
+            </b-field>
+            <b-field
+                :type="formErrors.abi ? 'is-danger' : ''"
+                :message="formErrors.abi"
+                label="ABI (JSON array)"
+            >
+                <b-input
+                    v-model="manual.abi"
+                    type="textarea"
+                    rows="6"
+                    placeholder='[{"type":"function","name":"transfer", ...}]'
+                ></b-input>
+            </b-field>
+            <div class="picker-actions">
+                <button type="button" class="button is-rounded is-primary" @click="applyManual">Use this contract</button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { address as Address } from 'thor-devkit'
+import DB, { Entities } from '../../database'
+import { BuiltInContractsService } from '../../services/builtin-contracts-service'
+
+interface PickerOption {
+    name: string
+    address: string
+    abi: any[]
+    source: 'Library' | 'Built-in'
+}
+
+@Component
+export default class ContractPicker extends Vue {
+    @Prop({ required: true }) network!: string
+
+    private mode: 'library' | 'manual' = 'library'
+    private search: string = ''
+    private loading: boolean = false
+    private userContracts: Entities.Contract[] = []
+    private builtIns: PickerOption[] = []
+
+    private manual = {
+        name: '',
+        address: '',
+        abi: ''
+    }
+    private formErrors: { name: string; address: string; abi: string } = {
+        name: '',
+        address: '',
+        abi: ''
+    }
+
+    get options(): PickerOption[] {
+        const user: PickerOption[] = this.userContracts
+            .filter(c => Array.isArray(c.abi) && (c.abi as any[]).length > 0)
+            .map(c => ({
+                name: c.name || 'Unnamed',
+                address: c.address || '',
+                abi: c.abi as any[],
+                source: 'Library' as const
+            }))
+        // de-dupe: prefer user library over built-ins by address
+        const known = new Set(user.map(o => o.address.toLowerCase()))
+        const builtins = this.builtIns.filter(o => !known.has((o.address || '').toLowerCase()))
+        return [...user, ...builtins]
+    }
+
+    get filtered(): PickerOption[] {
+        const q = this.search.trim().toLowerCase()
+        if (!q) return this.options
+        return this.options.filter(o =>
+            o.name.toLowerCase().includes(q) ||
+            (o.address && o.address.toLowerCase().includes(q))
+        )
+    }
+
+    private badgeClass(src: string) {
+        return src === 'Built-in' ? 'is-builtin' : 'is-library'
+    }
+
+    private onSelect(option: PickerOption | null) {
+        if (!option) return
+        if (!option.address || !Address.test(option.address)) {
+            this.$buefy.toast.open({
+                message: 'This built-in contract has no address on the current network. Use manual entry.',
+                type: 'is-warning',
+                position: 'is-bottom'
+            })
+            return
+        }
+        this.$emit('pick', {
+            address: option.address,
+            name: option.name,
+            abi: option.abi
+        })
+        this.search = ''
+    }
+
+    private applyManual() {
+        this.formErrors = { name: '', address: '', abi: '' }
+        const name = this.manual.name.trim()
+        const address = this.manual.address.trim()
+        const abiRaw = this.manual.abi.trim()
+
+        if (!name) this.formErrors.name = 'Name is required'
+        if (!address) this.formErrors.address = 'Address is required'
+        else if (!Address.test(address)) this.formErrors.address = 'Invalid address'
+        if (!abiRaw) this.formErrors.abi = 'ABI is required'
+
+        let abi: any[] = []
+        if (abiRaw && !this.formErrors.abi) {
+            try {
+                const parsed = JSON.parse(abiRaw)
+                if (!Array.isArray(parsed)) {
+                    this.formErrors.abi = 'ABI must be a JSON array'
+                } else {
+                    abi = parsed
+                }
+            } catch (e: any) {
+                this.formErrors.abi = 'Invalid JSON: ' + e.message
+            }
+        }
+
+        if (this.formErrors.name || this.formErrors.address || this.formErrors.abi) return
+
+        this.$emit('pick', { address, name, abi })
+        this.manual = { name: '', address: '', abi: '' }
+    }
+
+    @Watch('network')
+    private onNetworkChange() {
+        this.load()
+    }
+
+    private async load() {
+        this.loading = true
+        try {
+            this.userContracts = await DB.contracts
+                .filter(item => (item.network === this.network) || (item.network === undefined))
+                .toArray()
+        } catch (e) {
+            console.error('Failed to load user contracts', e)
+        }
+        try {
+            const results = await BuiltInContractsService.getBuiltInContracts(this.network)
+            this.builtIns = results
+                .filter(r => r.success && r.contract && Array.isArray(r.contract.abi) && (r.contract.abi as any[]).length > 0)
+                .map(r => ({
+                    name: r.contract!.name || 'Built-in',
+                    address: r.contract!.address || '',
+                    abi: r.contract!.abi as any[],
+                    source: 'Built-in' as const
+                }))
+        } catch (e) {
+            console.error('Failed to load built-in contracts', e)
+        }
+        this.loading = false
+    }
+
+    created() {
+        this.load()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.contract-picker {
+    width: 100%;
+}
+.picker-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 1rem;
+}
+.picker-tab {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-color);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+.picker-tab.is-active {
+    color: var(--primary-color);
+    border-bottom-color: var(--primary-color);
+    font-weight: 600;
+}
+.picker-tab:hover:not(.is-active) {
+    color: var(--text-color-strong);
+}
+.picker-body {
+    padding-top: 0.25rem;
+}
+.picker-row {
+    padding: 0.25rem 0;
+}
+.picker-row__name {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.picker-row__badge {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 8px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+.picker-row__badge.is-library {
+    background: rgba(50, 115, 220, 0.12);
+    color: #3273dc;
+}
+.picker-row__badge.is-builtin {
+    background: rgba(120, 80, 200, 0.12);
+    color: #7850c8;
+}
+.picker-row__addr {
+    font-size: 0.75rem;
+    color: var(--text-color-light);
+}
+.picker-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+[data-theme="dark"] {
+    .picker-row__badge.is-library {
+        background: rgba(107, 182, 255, 0.18);
+        color: #6bb6ff;
+    }
+    .picker-row__badge.is-builtin {
+        background: rgba(180, 140, 240, 0.18);
+        color: #b48cf0;
+    }
+}
+</style>

--- a/src/components/TxBuilder/DraftsMenu.vue
+++ b/src/components/TxBuilder/DraftsMenu.vue
@@ -1,0 +1,260 @@
+<template>
+    <div class="drafts-menu">
+        <b-dropdown aria-role="list" position="is-bottom-right" append-to-body>
+            <template #trigger>
+                <button type="button" class="button is-small">
+                    <b-icon icon="folder-open" size="is-small"></b-icon>
+                    <span>Drafts</span>
+                    <span v-if="drafts.length" class="drafts-count">{{ drafts.length }}</span>
+                    <b-icon icon="caret-down" size="is-small"></b-icon>
+                </button>
+            </template>
+
+            <b-dropdown-item custom>
+                <span class="dropdown-section-label">Current network only</span>
+            </b-dropdown-item>
+
+            <b-dropdown-item v-if="drafts.length === 0" custom>
+                <span class="has-text-grey-light">No drafts saved yet</span>
+            </b-dropdown-item>
+
+            <b-dropdown-item
+                v-for="d in drafts"
+                :key="d.id"
+                custom
+                class="draft-row"
+            >
+                <div class="draft-row__main" @click="$emit('load', d)">
+                    <div class="draft-row__name">
+                        {{ d.name }}
+                        <span v-if="loadedDraftId === d.id" class="badge-loaded">loaded</span>
+                    </div>
+                    <div class="draft-row__meta">
+                        {{ d.clauses.length }} clause{{ d.clauses.length === 1 ? '' : 's' }} · {{ formatTime(d.updatedTime) }}
+                    </div>
+                </div>
+                <div class="draft-row__actions">
+                    <button type="button" class="icon-btn" title="Rename" @click.stop="onRename(d)">
+                        <b-icon icon="pen" size="is-small"></b-icon>
+                    </button>
+                    <button type="button" class="icon-btn icon-btn--danger" title="Delete" @click.stop="onDelete(d)">
+                        <b-icon icon="trash" size="is-small"></b-icon>
+                    </button>
+                </div>
+            </b-dropdown-item>
+
+            <hr class="dropdown-divider">
+
+            <b-dropdown-item :disabled="!loadedDraftId || !dirty" @click="$emit('save')">
+                <b-icon icon="save" size="is-small"></b-icon>
+                <span>Save</span>
+            </b-dropdown-item>
+            <b-dropdown-item :disabled="!workspaceHasContent" @click="$emit('save-as')">
+                <b-icon icon="save" size="is-small"></b-icon>
+                <span>Save as…</span>
+            </b-dropdown-item>
+        </b-dropdown>
+
+        <div v-if="loadedDraftId && currentDraft" class="loaded-indicator">
+            <b-icon icon="circle" size="is-small" :class="{ 'has-text-warning': dirty, 'has-text-success': !dirty }"></b-icon>
+            <span class="loaded-name">{{ currentDraft.name }}</span>
+            <span v-if="dirty" class="loaded-dirty">· unsaved changes</span>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import DB, { Entities } from '../../database'
+
+@Component
+export default class DraftsMenu extends Vue {
+    @Prop({ required: true }) network!: string
+    @Prop({ default: null }) loadedDraftId!: number | null
+    @Prop({ default: false }) dirty!: boolean
+    @Prop({ default: false }) workspaceHasContent!: boolean
+
+    private drafts: Entities.TxBuilderDraft[] = []
+
+    get currentDraft(): Entities.TxBuilderDraft | null {
+        if (this.loadedDraftId === null) return null
+        return this.drafts.find(d => d.id === this.loadedDraftId) || null
+    }
+
+    private async reload() {
+        if (!this.network) {
+            this.drafts = []
+            return
+        }
+        this.drafts = await DB.txBuilderDrafts
+            .where('network')
+            .equals(this.network)
+            .reverse()
+            .sortBy('updatedTime')
+    }
+
+    private formatTime(t: number) {
+        const d = new Date(t)
+        const today = new Date()
+        if (d.toDateString() === today.toDateString()) {
+            return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+        }
+        return d.toLocaleDateString()
+    }
+
+    private onRename(d: Entities.TxBuilderDraft) {
+        this.$buefy.dialog.prompt({
+            title: 'Rename draft',
+            message: 'Enter a new name for this draft.',
+            inputAttrs: { value: d.name, maxlength: 60, required: true },
+            onConfirm: async (val: string) => {
+                const name = val.trim()
+                if (!name) return
+                await DB.txBuilderDrafts.update(d.id!, { name, updatedTime: Date.now() })
+                await this.reload()
+                this.$emit('renamed', { id: d.id, name })
+            }
+        })
+    }
+
+    private onDelete(d: Entities.TxBuilderDraft) {
+        this.$buefy.dialog.confirm({
+            title: 'Delete draft',
+            message: `Delete draft "${d.name}"? This cannot be undone.`,
+            confirmText: 'Delete',
+            type: 'is-danger',
+            onConfirm: async () => {
+                await DB.txBuilderDrafts.delete(d.id!)
+                await this.reload()
+                this.$emit('deleted', d.id)
+            }
+        })
+    }
+
+    @Watch('network')
+    private onNetworkChange() {
+        this.reload()
+    }
+
+    created() {
+        this.reload()
+        DB.subscribe('txBuilderDrafts', () => this.reload())
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.drafts-menu {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+::v-deep .dropdown-menu {
+    min-width: 280px;
+}
+::v-deep .dropdown-content {
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+::v-deep .dropdown-item {
+    color: var(--text-color);
+}
+::v-deep .dropdown-item:hover {
+    background-color: var(--body-background-alt);
+    color: var(--text-color-strong);
+}
+::v-deep .dropdown-item.is-disabled,
+::v-deep .dropdown-item[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+::v-deep .dropdown-divider {
+    background-color: var(--border-color);
+}
+.drafts-count {
+    background: var(--body-background-alt);
+    color: var(--text-color-light);
+    border-radius: 8px;
+    padding: 0 0.3rem;
+    font-size: 0.7rem;
+    margin-left: 0.3rem;
+    font-weight: 600;
+}
+.dropdown-section-label {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.draft-row {
+    display: flex !important;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem !important;
+    gap: 0.5rem;
+}
+.draft-row__main {
+    flex: 1;
+    min-width: 0;
+    cursor: pointer;
+}
+.draft-row__name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.draft-row__meta {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+}
+.badge-loaded {
+    font-size: 0.6rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 6px;
+    background: rgba(50, 115, 220, 0.15);
+    color: var(--primary-color);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.draft-row__actions {
+    display: flex;
+    gap: 0.2rem;
+    flex-shrink: 0;
+}
+.icon-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-color-light);
+    cursor: pointer;
+    padding: 0.2rem;
+    border-radius: 4px;
+}
+.icon-btn:hover {
+    color: var(--text-color-strong);
+    background: var(--body-background-alt);
+}
+.icon-btn--danger:hover {
+    color: #ff3860;
+}
+
+.loaded-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.8rem;
+    color: var(--text-color-light);
+}
+.loaded-name {
+    font-weight: 600;
+    color: var(--text-color);
+}
+.loaded-dirty {
+    color: #b88010;
+    font-size: 0.75rem;
+}
+</style>

--- a/src/components/TxBuilder/ParamInput.vue
+++ b/src/components/TxBuilder/ParamInput.vue
@@ -1,0 +1,68 @@
+<template>
+    <div class="param-input">
+        <div v-if="input.type === 'bool'" class="bool-group">
+            <b-radio :value="value" :native-value="true" @input="onChange">True</b-radio>
+            <b-radio :value="value" :native-value="false" @input="onChange">False</b-radio>
+        </div>
+        <div v-else class="text-input-wrapper">
+            <b-input
+                custom-class="is-family-monospace has-text-weight-semibold"
+                :class="{ 'is-invalid': showError }"
+                :value="value"
+                :placeholder="input.type"
+                @input="onChange"
+            ></b-input>
+            <span v-if="showError" class="param-error">{{ validation.error }}</span>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { validateParam, ParamValidation } from '../../utils/param-validation'
+
+@Component
+export default class ParamInput extends Vue {
+    @Prop({ required: true }) input!: ABI.InputItem
+    @Prop({ default: '' }) value!: any
+
+    get validation(): ParamValidation {
+        return validateParam(this.value, this.input.type)
+    }
+
+    get showError(): boolean {
+        const v = this.value
+        if (v === null || v === undefined || v === '') return false
+        return !this.validation.valid
+    }
+
+    private onChange(val: any) {
+        this.$emit('input', val)
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.param-input {
+    width: 100%;
+}
+.bool-group {
+    display: flex;
+    gap: 1rem;
+}
+.text-input-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+.param-error {
+    font-size: 0.7rem;
+    color: #ff3860;
+}
+.param-input ::v-deep .is-invalid input,
+.param-input ::v-deep .is-invalid textarea {
+    border-color: #ff3860 !important;
+    box-shadow: 0 0 0 0.125em rgba(255, 56, 96, 0.15);
+}
+</style>

--- a/src/components/TxBuilder/RoleSelector.vue
+++ b/src/components/TxBuilder/RoleSelector.vue
@@ -1,0 +1,292 @@
+<template>
+    <div class="role-selector">
+        <div class="role-row">
+            <b-dropdown
+                aria-role="list"
+                position="is-bottom-right"
+                expanded
+                :disabled="loading"
+                @change="onSelect"
+            >
+                <template #trigger>
+                    <button type="button" class="button role-trigger">
+                        <span v-if="loading" class="has-text-grey-light">Loading roles…</span>
+                        <span v-else-if="matchedName" class="role-trigger__main">
+                            <span class="role-name">{{ matchedName }}</span>
+                        </span>
+                        <span v-else-if="value" class="role-trigger__main">
+                            <span class="role-name has-text-grey">Custom</span>
+                            <span class="role-hash is-family-monospace">{{ shortHash(value) }}</span>
+                        </span>
+                        <span v-else class="has-text-grey-light">Select a role…</span>
+                        <b-icon icon="caret-down" size="is-small"></b-icon>
+                    </button>
+                </template>
+
+                <b-dropdown-item custom>
+                    <b-input
+                        v-model="search"
+                        placeholder="Filter by name or hash"
+                        size="is-small"
+                        icon="search"
+                    ></b-input>
+                </b-dropdown-item>
+
+                <b-dropdown-item v-if="!loading && filtered.length === 0" custom>
+                    <span class="has-text-grey-light">No roles match.</span>
+                </b-dropdown-item>
+
+                <b-dropdown-item
+                    v-for="r in filtered"
+                    :key="r.hash"
+                    :value="r.hash"
+                    class="role-option"
+                >
+                    <div class="role-option__name">{{ r.name }}</div>
+                    <div class="role-option__hash is-family-monospace">{{ shortHash(r.hash) }}</div>
+                </b-dropdown-item>
+            </b-dropdown>
+
+            <button
+                type="button"
+                class="button is-small refresh-btn"
+                title="Refresh roles from chain"
+                :disabled="loading"
+                @click="reload(true)"
+            >
+                <b-icon icon="sync-alt" size="is-small" :class="{ 'is-spinning': loading }"></b-icon>
+            </button>
+        </div>
+
+        <div class="manual-row">
+            <b-input
+                custom-class="is-family-monospace"
+                size="is-small"
+                :value="value"
+                :placeholder="'Or paste bytes32 (0x' + '0'.repeat(64) + ')'"
+                @input="onManualInput"
+            ></b-input>
+            <span v-if="manualError" class="manual-error">{{ manualError }}</span>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { discoverContractRoles, clearRoleCache, DiscoveredRole } from '../../utils/role-discovery'
+
+@Component
+export default class RoleSelector extends Vue {
+    @Prop({ required: true }) contractAddress!: string
+    @Prop({ required: true }) abi!: any[]
+    @Prop({ required: true }) network!: string
+    @Prop({ default: '' }) value!: string
+
+    private roles: DiscoveredRole[] = []
+    private loading: boolean = false
+    private search: string = ''
+    private manualError: string = ''
+
+    get matchedName(): string | null {
+        if (!this.value) return null
+        const v = this.value.toLowerCase()
+        const found = this.roles.find(r => r.hash === v)
+        return found ? found.name : null
+    }
+
+    get filtered(): DiscoveredRole[] {
+        const q = this.search.trim().toLowerCase()
+        if (!q) return this.roles
+        return this.roles.filter(r =>
+            r.name.toLowerCase().includes(q) || r.hash.toLowerCase().includes(q)
+        )
+    }
+
+    private shortHash(hash: string): string {
+        if (!hash) return ''
+        if (hash.length <= 16) return hash
+        return hash.substring(0, 10) + '…' + hash.substring(hash.length - 6)
+    }
+
+    private async reload(force: boolean = false) {
+        if (!this.contractAddress || !this.abi) return
+        this.loading = true
+        try {
+            if (force) clearRoleCache(this.network, this.contractAddress)
+            this.roles = await discoverContractRoles(
+                this.$connex,
+                this.network,
+                this.contractAddress,
+                this.abi
+            )
+        } catch (e) {
+            console.error('Role discovery failed', e)
+        } finally {
+            this.loading = false
+        }
+    }
+
+    private onSelect(hash: string) {
+        if (!hash) return
+        this.manualError = ''
+        this.$emit('input', hash.toLowerCase())
+    }
+
+    private onManualInput(val: string) {
+        const v = (val || '').trim()
+        if (!v) {
+            this.manualError = ''
+            this.$emit('input', '')
+            return
+        }
+        if (!/^0x[0-9a-fA-F]{0,64}$/.test(v)) {
+            this.manualError = 'Must be hex (0x…)'
+        } else if (v.length !== 66) {
+            this.manualError = `Bytes32 needs 64 hex chars (${v.length - 2}/64)`
+        } else {
+            this.manualError = ''
+        }
+        this.$emit('input', v.toLowerCase())
+    }
+
+    @Watch('contractAddress')
+    private onContractChange() {
+        this.roles = []
+        this.reload()
+    }
+
+    @Watch('abi')
+    private onAbiChange() {
+        this.roles = []
+        this.reload()
+    }
+
+    created() {
+        this.reload()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.role-selector {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.role-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.role-trigger {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: var(--input-background);
+    border: 1px solid var(--input-border);
+    color: var(--text-color);
+    text-align: left;
+}
+.role-trigger:hover,
+.role-trigger:focus {
+    border-color: var(--primary-color);
+    background-color: var(--input-background);
+    color: var(--text-color);
+    box-shadow: none;
+}
+.role-trigger:hover .role-name,
+.role-trigger:focus .role-name {
+    color: var(--text-color-strong);
+}
+.role-trigger:hover .role-hash,
+.role-trigger:focus .role-hash {
+    color: var(--text-color-light);
+}
+.role-trigger__main {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.1rem;
+    flex: 1;
+    min-width: 0;
+}
+.role-name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+    font-size: 0.85rem;
+}
+.role-hash {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+}
+
+.refresh-btn {
+    flex-shrink: 0;
+}
+.refresh-btn .is-spinning {
+    animation: spin 1s linear infinite;
+}
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.role-option {
+    padding: 0.4rem 0.75rem !important;
+}
+.role-option__name {
+    font-weight: 600;
+    color: var(--text-color-strong);
+    font-size: 0.85rem;
+}
+.role-option__hash {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+}
+
+.manual-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+.manual-error {
+    font-size: 0.7rem;
+    color: #ff3860;
+}
+
+::v-deep .dropdown {
+    width: 100%;
+}
+::v-deep .dropdown-trigger {
+    width: 100%;
+}
+::v-deep .dropdown-menu {
+    min-width: 100%;
+    width: 100%;
+}
+::v-deep .dropdown-content {
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    max-height: 360px;
+    overflow-y: auto;
+}
+::v-deep .dropdown-item,
+::v-deep a.dropdown-item {
+    color: var(--text-color);
+}
+::v-deep .dropdown-item:hover,
+::v-deep a.dropdown-item:hover {
+    background-color: var(--body-background-alt);
+    color: var(--text-color);
+}
+::v-deep .dropdown-item:hover .role-option__name {
+    color: var(--text-color-strong);
+}
+::v-deep .dropdown-item:hover .role-option__hash {
+    color: var(--text-color-light);
+}
+</style>

--- a/src/database.ts
+++ b/src/database.ts
@@ -41,6 +41,26 @@ export namespace Entities {
     roleHash: string; // bytes32
     createdTime: number;
   }
+
+  export interface TxBuilderClause {
+    id: string;
+    contractAddress: string;
+    contractName: string;
+    abi: any[];
+    selectedFunction: ABI.FunctionItem | null;
+    params: string[];
+    value: string | null;
+    note?: string;
+  }
+
+  export interface TxBuilderDraft {
+    id?: number;
+    name: string;
+    network: string; // genesis ID
+    clauses: TxBuilderClause[];
+    createdTime: number;
+    updatedTime: number;
+  }
 }
 
 class Database extends Dexie {
@@ -49,6 +69,7 @@ class Database extends Dexie {
   public readonly shortCuts!: Dexie.Table<Entities.ShortCuts, number>;
   public readonly networks!: Dexie.Table<Entities.Network, number>;
   public readonly customRoles!: Dexie.Table<Entities.CustomRole, number>;
+  public readonly txBuilderDrafts!: Dexie.Table<Entities.TxBuilderDraft, number>;
 
   constructor() {
     super("inspect");
@@ -77,6 +98,9 @@ class Database extends Dexie {
     });
     this.version(8).stores({
       customRoles: "++id, contractAddress, network",
+    });
+    this.version(9).stores({
+      txBuilderDrafts: "++id, name, network, updatedTime",
     });
     this.open().catch((err) => {
       // tslint:disable-next-line:no-console

--- a/src/utils/param-validation.ts
+++ b/src/utils/param-validation.ts
@@ -1,0 +1,88 @@
+import { address as Address } from 'thor-devkit'
+
+export interface ParamValidation {
+    valid: boolean
+    error?: string
+}
+
+const HEX_RE = /^0x[0-9a-fA-F]*$/
+const UINT_RE = /^\d+$/
+const INT_RE = /^-?\d+$/
+
+export function validateParam(value: any, type: string): ParamValidation {
+    if (value === null || value === undefined || value === '') {
+        return { valid: false, error: 'Required' }
+    }
+    if (type === 'bool') {
+        return value === true || value === false ? { valid: true } : { valid: false, error: 'Must be true or false' }
+    }
+
+    const v = String(value).trim()
+
+    if (type === 'address') {
+        return Address.test(v) ? { valid: true } : { valid: false, error: 'Invalid address' }
+    }
+
+    if (type.endsWith(']')) {
+        try {
+            const parsed = JSON.parse(v)
+            return Array.isArray(parsed) ? { valid: true } : { valid: false, error: 'Must be a JSON array' }
+        } catch {
+            return { valid: false, error: 'Invalid JSON' }
+        }
+    }
+
+    const uintMatch = /^uint(\d*)$/.exec(type)
+    if (uintMatch) {
+        if (!UINT_RE.test(v)) return { valid: false, error: 'Must be a non-negative integer' }
+        const bits = uintMatch[1] ? parseInt(uintMatch[1], 10) : 256
+        try {
+            const max = BN(2).pow(bits).minus(1)
+            const bn = BN(v)
+            if (bn.isGreaterThan(max)) return { valid: false, error: `Exceeds uint${bits} max` }
+        } catch {
+            return { valid: false, error: 'Invalid number' }
+        }
+        return { valid: true }
+    }
+
+    const intMatch = /^int(\d*)$/.exec(type)
+    if (intMatch) {
+        if (!INT_RE.test(v)) return { valid: false, error: 'Must be an integer' }
+        const bits = intMatch[1] ? parseInt(intMatch[1], 10) : 256
+        try {
+            const max = BN(2).pow(bits - 1).minus(1)
+            const min = BN(2).pow(bits - 1).negated()
+            const bn = BN(v)
+            if (bn.isGreaterThan(max) || bn.isLessThan(min)) {
+                return { valid: false, error: `Out of int${bits} range` }
+            }
+        } catch {
+            return { valid: false, error: 'Invalid number' }
+        }
+        return { valid: true }
+    }
+
+    if (type === 'bytes') {
+        if (!HEX_RE.test(v)) return { valid: false, error: 'Must be hex (0x…)' }
+        if ((v.length - 2) % 2 !== 0) return { valid: false, error: 'Hex must have even length' }
+        return { valid: true }
+    }
+
+    const bytesNMatch = /^bytes(\d+)$/.exec(type)
+    if (bytesNMatch) {
+        const n = parseInt(bytesNMatch[1], 10)
+        if (!HEX_RE.test(v)) return { valid: false, error: 'Must be hex (0x…)' }
+        const expectedLen = 2 + n * 2
+        if (v.length !== expectedLen) {
+            return { valid: false, error: `Expected ${n * 2} hex chars (${v.length - 2}/${n * 2})` }
+        }
+        return { valid: true }
+    }
+
+    if (type === 'string') {
+        return { valid: true }
+    }
+
+    return { valid: true }
+}

--- a/src/utils/role-discovery.ts
+++ b/src/utils/role-discovery.ts
@@ -1,0 +1,119 @@
+import Connex from '@vechain/connex'
+
+export interface DiscoveredRole {
+    name: string
+    hash: string
+}
+
+const CACHE_KEY = 'tx-builder-roles-cache-v1'
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+const DEFAULT_ADMIN_ROLE = '0x' + '0'.repeat(64)
+
+interface CacheEntry {
+    timestamp: number
+    roles: DiscoveredRole[]
+}
+
+interface CacheShape {
+    [key: string]: CacheEntry
+}
+
+function readCache(): CacheShape {
+    try {
+        const raw = localStorage.getItem(CACHE_KEY)
+        if (!raw) return {}
+        return JSON.parse(raw) as CacheShape
+    } catch {
+        return {}
+    }
+}
+
+function writeCache(cache: CacheShape) {
+    try {
+        localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+    } catch {
+        /* ignore quota errors */
+    }
+}
+
+function cacheKey(network: string, address: string): string {
+    return `${network.toLowerCase()}:${address.toLowerCase()}`
+}
+
+function isRoleGetter(item: any): boolean {
+    if (!item || item.type !== 'function') return false
+    if (item.inputs && item.inputs.length > 0) return false
+    if (!item.outputs || item.outputs.length !== 1) return false
+    if (item.outputs[0].type !== 'bytes32') return false
+    const mutability = item.stateMutability || (item.constant ? 'view' : 'nonpayable')
+    if (mutability !== 'view' && mutability !== 'pure') return false
+    if (!item.name || !/^[A-Z][A-Z0-9_]*$/.test(item.name)) return false
+    return true
+}
+
+export function isRoleParam(input: ABI.InputItem | undefined): boolean {
+    if (!input) return false
+    return input.type === 'bytes32' && /role/i.test(input.name || '')
+}
+
+export async function discoverContractRoles(
+    connex: Connex,
+    network: string,
+    address: string,
+    abi: any[]
+): Promise<DiscoveredRole[]> {
+    const key = cacheKey(network, address)
+    const cache = readCache()
+    const entry = cache[key]
+    if (entry && Date.now() - entry.timestamp < CACHE_TTL_MS) {
+        return entry.roles
+    }
+
+    const getters = (abi || []).filter(isRoleGetter)
+    const account = connex.thor.account(address.toLowerCase())
+
+    const calls = getters.map(async (g: any) => {
+        try {
+            const method = account.method(g)
+            const result = await method.call()
+            if (result.reverted) return null
+            const hash = result.decoded && (result.decoded['0'] as string)
+            if (!hash || !/^0x[0-9a-fA-F]{64}$/.test(hash)) return null
+            return { name: g.name as string, hash: hash.toLowerCase() }
+        } catch {
+            return null
+        }
+    })
+
+    const settled = await Promise.all(calls)
+    const seen = new Set<string>()
+    const roles: DiscoveredRole[] = [{ name: 'DEFAULT_ADMIN_ROLE', hash: DEFAULT_ADMIN_ROLE }]
+    seen.add(DEFAULT_ADMIN_ROLE)
+    for (const r of settled) {
+        if (!r) continue
+        if (seen.has(r.hash)) continue
+        seen.add(r.hash)
+        roles.push(r)
+    }
+
+    roles.sort((a, b) => {
+        if (a.name === 'DEFAULT_ADMIN_ROLE') return -1
+        if (b.name === 'DEFAULT_ADMIN_ROLE') return 1
+        return a.name.localeCompare(b.name)
+    })
+
+    cache[key] = { timestamp: Date.now(), roles }
+    writeCache(cache)
+
+    return roles
+}
+
+export function clearRoleCache(network?: string, address?: string) {
+    if (!network || !address) {
+        localStorage.removeItem(CACHE_KEY)
+        return
+    }
+    const cache = readCache()
+    delete cache[cacheKey(network, address)]
+    writeCache(cache)
+}

--- a/src/views/TxBuilder.vue
+++ b/src/views/TxBuilder.vue
@@ -53,8 +53,8 @@
             </div>
         </div>
 
-        <!-- Sticky footer -->
-        <div class="tx-builder-footer">
+        <!-- Sticky footer · normal mode -->
+        <div v-if="!submission" class="tx-builder-footer">
             <div class="footer-summary">
                 <span class="summary-pill" :class="allValid ? 'is-valid' : 'is-pending'">
                     <span class="summary-dot"></span>
@@ -82,6 +82,77 @@
                 </button>
             </div>
         </div>
+
+        <!-- Sticky footer · submission mode -->
+        <div v-else class="tx-builder-footer is-submission" :class="'is-' + submission.status">
+            <div class="submission-main">
+                <div class="submission-icon">
+                    <b-icon
+                        v-if="submission.status === 'submitting' || submission.status === 'pending'"
+                        icon="circle-notch"
+                        custom-class="fa-spin"
+                    ></b-icon>
+                    <b-icon v-else-if="submission.status === 'confirmed'" icon="check-circle"></b-icon>
+                    <b-icon v-else-if="submission.status === 'reverted'" icon="times-circle"></b-icon>
+                    <b-icon v-else-if="submission.status === 'timeout'" icon="exclamation-circle"></b-icon>
+                    <b-icon v-else icon="exclamation-triangle"></b-icon>
+                </div>
+                <div class="submission-text">
+                    <div class="submission-status">{{ statusLabel }}</div>
+                    <div class="submission-meta">
+                        <span v-if="submission.txid" class="submission-txid is-family-monospace">
+                            {{ submission.txid | addr }}
+                        </span>
+                        <a
+                            v-if="submission.txid"
+                            :href="$explorerTx + submission.txid"
+                            target="_blank"
+                            rel="noopener"
+                            class="submission-link"
+                        >
+                            View on explorer
+                            <b-icon icon="external-link-alt" size="is-small"></b-icon>
+                        </a>
+                        <span v-if="submission.receipt && submission.receipt.gasUsed" class="submission-aux">
+                            · gas {{ submission.receipt.gasUsed.toLocaleString() }}
+                        </span>
+                        <span v-if="submission.receipt && submission.receipt.meta && submission.receipt.meta.blockNumber" class="submission-aux">
+                            · block {{ submission.receipt.meta.blockNumber }}
+                        </span>
+                        <span v-if="submission.error" class="submission-error">
+                            · {{ submission.error }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <div class="footer-actions">
+                <button
+                    v-if="submission.status === 'confirmed'"
+                    type="button"
+                    class="button is-rounded is-primary"
+                    @click="dismissAndReset"
+                >
+                    Start new
+                </button>
+                <button
+                    v-else-if="submission.status !== 'submitting' && submission.status !== 'pending'"
+                    type="button"
+                    class="button is-rounded"
+                    @click="dismissSubmission"
+                >
+                    Dismiss
+                </button>
+                <button
+                    v-else
+                    type="button"
+                    class="button is-rounded"
+                    @click="dismissSubmission"
+                    title="Stop tracking — the transaction will keep its course on-chain"
+                >
+                    Hide
+                </button>
+            </div>
+        </div>
     </section>
 </template>
 
@@ -99,6 +170,15 @@ interface EncodedClause {
     data: string
     comment?: string
     error?: string
+}
+
+type SubmissionStatus = 'submitting' | 'pending' | 'confirmed' | 'reverted' | 'timeout' | 'error'
+
+interface Submission {
+    status: SubmissionStatus
+    txid: string | null
+    receipt: Connex.Thor.Transaction.Receipt | null
+    error: string | null
 }
 
 function uid(): string {
@@ -131,6 +211,9 @@ export default class TxBuilder extends Vue {
     private dirty: boolean = false
     private submitting: boolean = false
     private suppressDirty: boolean = false
+    private submission: Submission | null = null
+    private pollIntervalId: number | null = null
+    private pollTimeoutId: number | null = null
 
     get network(): string {
         return this.$connex.thor.genesis.id
@@ -160,7 +243,20 @@ export default class TxBuilder extends Vue {
     }
 
     get canSubmit(): boolean {
-        return this.allValid && !this.submitting
+        return this.allValid && !this.submitting && !this.submission
+    }
+
+    get statusLabel(): string {
+        if (!this.submission) return ''
+        switch (this.submission.status) {
+            case 'submitting': return 'Awaiting signature…'
+            case 'pending': return 'Pending — waiting for confirmation'
+            case 'confirmed': return 'Confirmed'
+            case 'reverted': return 'Reverted on-chain'
+            case 'timeout': return 'Timed out waiting for receipt'
+            case 'error': return 'Submission failed'
+            default: return ''
+        }
     }
 
     get contractsTouched(): number {
@@ -348,18 +444,17 @@ export default class TxBuilder extends Vue {
 
         if (clauses.length === 0) return
         this.submitting = true
+        this.submission = { status: 'submitting', txid: null, receipt: null, error: null }
         try {
             const resp = await this.$connex.vendor
                 .sign('tx', clauses)
                 .comment('Inspector TX Builder')
                 .request()
             if (resp && resp.txid) {
-                this.$buefy.toast.open({
-                    message: 'Transaction submitted',
-                    type: 'is-success',
-                    position: 'is-bottom'
-                })
-                window.open(`${this.$explorerTx}${resp.txid}`)
+                this.submission = { status: 'pending', txid: resp.txid, receipt: null, error: null }
+                this.startReceiptPolling(resp.txid)
+            } else {
+                this.submission = null
             }
         } catch (error: any) {
             const msg = (error && error.message) || ''
@@ -370,17 +465,104 @@ export default class TxBuilder extends Vue {
                 msg.toLowerCase().includes('denied') ||
                 name.toLowerCase().includes('rejected') ||
                 name.toLowerCase().includes('cancel')
-            if (!isUserRejection) {
-                this.$buefy.toast.open({
-                    message: `${name || 'Error'}: ${msg || 'Submission failed'}`,
-                    type: 'is-danger',
-                    position: 'is-bottom',
-                    duration: 4000
-                })
+            if (isUserRejection) {
+                this.submission = null
+            } else {
+                this.submission = {
+                    status: 'error',
+                    txid: null,
+                    receipt: null,
+                    error: msg || 'Submission failed'
+                }
             }
         } finally {
             this.submitting = false
         }
+    }
+
+    private startReceiptPolling(txid: string) {
+        this.stopReceiptPolling()
+        const timeoutMs = 5 * 12000 // 60s — VeChain block time ~10s
+        const startTime = Date.now()
+
+        this.pollIntervalId = window.setInterval(async () => {
+            if (!this.submission || this.submission.txid !== txid) {
+                this.stopReceiptPolling()
+                return
+            }
+            try {
+                const receipt = await this.$connex.thor.transaction(txid).getReceipt()
+                if (receipt) {
+                    this.submission = {
+                        status: receipt.reverted ? 'reverted' : 'confirmed',
+                        txid,
+                        receipt,
+                        error: receipt.reverted ? 'Transaction reverted' : null
+                    }
+                    this.stopReceiptPolling()
+                    return
+                }
+                if (Date.now() - startTime > timeoutMs) {
+                    this.submission = {
+                        status: 'timeout',
+                        txid,
+                        receipt: null,
+                        error: null
+                    }
+                    this.stopReceiptPolling()
+                }
+            } catch {
+                if (Date.now() - startTime > timeoutMs) {
+                    this.submission = {
+                        status: 'timeout',
+                        txid,
+                        receipt: null,
+                        error: null
+                    }
+                    this.stopReceiptPolling()
+                }
+            }
+        }, 1000)
+
+        this.pollTimeoutId = window.setTimeout(() => {
+            if (this.submission && this.submission.status === 'pending') {
+                this.submission = {
+                    status: 'timeout',
+                    txid,
+                    receipt: null,
+                    error: null
+                }
+                this.stopReceiptPolling()
+            }
+        }, timeoutMs)
+    }
+
+    private stopReceiptPolling() {
+        if (this.pollIntervalId !== null) {
+            clearInterval(this.pollIntervalId)
+            this.pollIntervalId = null
+        }
+        if (this.pollTimeoutId !== null) {
+            clearTimeout(this.pollTimeoutId)
+            this.pollTimeoutId = null
+        }
+    }
+
+    private dismissSubmission() {
+        this.stopReceiptPolling()
+        this.submission = null
+    }
+
+    private dismissAndReset() {
+        this.dismissSubmission()
+        this.clauses = []
+        this.activeId = null
+        this.loadedDraftId = null
+        this.dirty = false
+    }
+
+    private beforeDestroy() {
+        this.stopReceiptPolling()
     }
 
     @Watch('network')
@@ -515,6 +697,98 @@ export default class TxBuilder extends Vue {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+}
+
+.tx-builder-footer.is-submission {
+    border-top-width: 2px;
+}
+.tx-builder-footer.is-submitting,
+.tx-builder-footer.is-pending {
+    border-top-color: #b88010;
+}
+.tx-builder-footer.is-confirmed {
+    border-top-color: #228822;
+}
+.tx-builder-footer.is-reverted,
+.tx-builder-footer.is-error {
+    border-top-color: #ff3860;
+}
+.tx-builder-footer.is-timeout {
+    border-top-color: #b88010;
+}
+
+.submission-main {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex: 1;
+    min-width: 0;
+}
+.submission-icon {
+    flex-shrink: 0;
+    font-size: 1.2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+}
+.is-submitting .submission-icon,
+.is-pending .submission-icon,
+.is-timeout .submission-icon {
+    color: #b88010;
+}
+.is-confirmed .submission-icon {
+    color: #228822;
+}
+.is-reverted .submission-icon,
+.is-error .submission-icon {
+    color: #ff3860;
+}
+.submission-text {
+    flex: 1;
+    min-width: 0;
+}
+.submission-status {
+    font-weight: 600;
+    color: var(--text-color-strong);
+    font-size: 0.9rem;
+}
+.submission-meta {
+    margin-top: 0.15rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+    flex-wrap: wrap;
+}
+.submission-txid {
+    color: var(--text-color);
+    font-weight: 600;
+}
+.submission-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    color: var(--primary-color);
+    text-decoration: none;
+}
+.submission-link:hover {
+    text-decoration: underline;
+}
+.submission-aux {
+    color: var(--text-color-light);
+}
+.submission-error {
+    color: #ff3860;
+}
+
+::v-deep .fa-spin {
+    animation: fa-spin 1.2s linear infinite;
+}
+@keyframes fa-spin {
+    to { transform: rotate(360deg); }
 }
 
 @keyframes pulse {

--- a/src/views/TxBuilder.vue
+++ b/src/views/TxBuilder.vue
@@ -185,6 +185,7 @@ function makeEmptyClause(): Entities.TxBuilderClause {
 }
 
 @Component({
+    name: 'TxBuilder',
     components: { ClauseList, ClauseEditor, DraftsMenu }
 })
 export default class TxBuilder extends Vue {

--- a/src/views/TxBuilder.vue
+++ b/src/views/TxBuilder.vue
@@ -1,0 +1,547 @@
+<template>
+    <section class="tx-builder-layout">
+        <!-- Header: drafts toolbar -->
+        <div class="tx-builder-header">
+            <DraftsMenu
+                :network="network"
+                :loadedDraftId="loadedDraftId"
+                :dirty="dirty"
+                :workspaceHasContent="clauses.length > 0"
+                @load="onLoadDraft"
+                @save="onSaveDraft"
+                @save-as="onSaveAsDraft"
+                @deleted="onDraftDeleted"
+                @renamed="onDraftRenamed"
+            />
+            <button type="button" class="button is-small is-light" :disabled="clauses.length === 0" @click="confirmReset">
+                <b-icon icon="eraser" size="is-small"></b-icon>
+                <span>Clear</span>
+            </button>
+        </div>
+
+        <!-- Main split: left rail + right pane -->
+        <div class="tx-builder-main">
+            <div class="clause-list-pane">
+                <ClauseList
+                    :clauses="clauses"
+                    :activeId="activeId"
+                    :encoded="encodedClauses"
+                    @select="onSelect"
+                    @add="onAdd"
+                    @remove="onRemove"
+                    @move="onMove"
+                />
+            </div>
+            <div class="clause-editor-pane">
+                <ClauseEditor
+                    v-if="activeClause"
+                    :key="activeClause.id"
+                    :clause="activeClause"
+                    :network="network"
+                    :encoded="activeEncoded"
+                    @update="onUpdateClause"
+                />
+                <div v-else class="empty-state">
+                    <b-icon icon="layer-group" size="is-large" custom-class="has-text-grey-light"></b-icon>
+                    <p class="empty-title">Build a transaction</p>
+                    <p class="empty-desc">Add one or more clauses, then sign &amp; submit as a single VeChain transaction.</p>
+                    <button type="button" class="button is-rounded is-primary" @click="onAdd">
+                        <b-icon icon="plus" size="is-small"></b-icon>
+                        <span>Add first clause</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Sticky footer -->
+        <div class="tx-builder-footer">
+            <div class="footer-summary">
+                <span class="summary-pill" :class="allValid ? 'is-valid' : 'is-pending'">
+                    <span class="summary-dot"></span>
+                    <span v-if="clauses.length === 0">No clauses</span>
+                    <span v-else-if="allValid">All {{ clauses.length }} clause{{ clauses.length === 1 ? '' : 's' }} ready</span>
+                    <span v-else>{{ validCount }} of {{ clauses.length }} clauses ready</span>
+                </span>
+                <span v-if="contractsTouched > 1" class="summary-aux">
+                    · touches {{ contractsTouched }} contracts — verify each
+                </span>
+            </div>
+            <div class="footer-actions">
+                <button type="button" class="button is-rounded" @click="confirmReset" :disabled="clauses.length === 0">
+                    Cancel
+                </button>
+                <button
+                    type="button"
+                    class="button is-rounded is-primary"
+                    :disabled="!canSubmit"
+                    :class="{ 'is-loading': submitting }"
+                    @click="submit"
+                >
+                    <b-icon icon="paper-plane" size="is-small"></b-icon>
+                    <span>Sign &amp; Submit</span>
+                </button>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Watch } from 'vue-property-decorator'
+import DB, { Entities } from '../database'
+import ClauseList from '../components/TxBuilder/ClauseList.vue'
+import ClauseEditor from '../components/TxBuilder/ClauseEditor.vue'
+import DraftsMenu from '../components/TxBuilder/DraftsMenu.vue'
+
+interface EncodedClause {
+    isValid: boolean
+    to: string
+    value: string
+    data: string
+    comment?: string
+    error?: string
+}
+
+function uid(): string {
+    if (typeof crypto !== 'undefined' && (crypto as any).randomUUID) {
+        return (crypto as any).randomUUID()
+    }
+    return 'c-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 9)
+}
+
+function makeEmptyClause(): Entities.TxBuilderClause {
+    return {
+        id: uid(),
+        contractAddress: '',
+        contractName: '',
+        abi: [],
+        selectedFunction: null,
+        params: [],
+        value: null,
+        note: ''
+    }
+}
+
+@Component({
+    components: { ClauseList, ClauseEditor, DraftsMenu }
+})
+export default class TxBuilder extends Vue {
+    private clauses: Entities.TxBuilderClause[] = []
+    private activeId: string | null = null
+    private loadedDraftId: number | null = null
+    private dirty: boolean = false
+    private submitting: boolean = false
+    private suppressDirty: boolean = false
+
+    get network(): string {
+        return this.$connex.thor.genesis.id
+    }
+
+    get activeClause(): Entities.TxBuilderClause | null {
+        if (!this.activeId) return null
+        return this.clauses.find(c => c.id === this.activeId) || null
+    }
+
+    get encodedClauses(): EncodedClause[] {
+        return this.clauses.map(c => this.encodeClause(c))
+    }
+
+    get activeEncoded(): EncodedClause | null {
+        const idx = this.clauses.findIndex(c => c.id === this.activeId)
+        if (idx === -1) return null
+        return this.encodedClauses[idx] || null
+    }
+
+    get validCount(): number {
+        return this.encodedClauses.filter(e => e.isValid).length
+    }
+
+    get allValid(): boolean {
+        return this.clauses.length > 0 && this.validCount === this.clauses.length
+    }
+
+    get canSubmit(): boolean {
+        return this.allValid && !this.submitting
+    }
+
+    get contractsTouched(): number {
+        const set = new Set<string>()
+        this.clauses.forEach(c => {
+            if (c.contractAddress) set.add(c.contractAddress.toLowerCase())
+        })
+        return set.size
+    }
+
+    private encodeClause(c: Entities.TxBuilderClause): EncodedClause {
+        if (!c.contractAddress) {
+            return { isValid: false, to: '', value: '0x0', data: '0x', error: 'Pick a contract' }
+        }
+        if (!c.selectedFunction) {
+            return { isValid: false, to: c.contractAddress, value: '0x0', data: '0x', error: 'Pick a function' }
+        }
+        const expected = c.selectedFunction.inputs ? c.selectedFunction.inputs.length : 0
+        if (c.params.length !== expected || c.params.some(p => p === '' || p === null || p === undefined)) {
+            return { isValid: false, to: c.contractAddress, value: '0x0', data: '0x', error: 'Fill all parameters' }
+        }
+        try {
+            const account = this.$connex.thor.account(c.contractAddress.toLowerCase())
+            const method = account.method(c.selectedFunction)
+            const params = c.params.map((p, i) => {
+                return c.selectedFunction!.inputs[i].type.endsWith(']') ? JSON.parse(p) : p
+            })
+            const payable = !!c.selectedFunction.payable || c.selectedFunction.stateMutability === 'payable'
+            const hexValue = '0x' + BN(payable ? (c.value || 0) : 0).multipliedBy(1e18).toFixed(0).toString(16)
+            const clause = method.value(hexValue).asClause(...params)
+            return {
+                isValid: true,
+                to: clause.to || c.contractAddress,
+                value: clause.value as string,
+                data: clause.data,
+                comment: c.note || c.selectedFunction.name
+            }
+        } catch (e: any) {
+            return {
+                isValid: false,
+                to: c.contractAddress,
+                value: '0x0',
+                data: '0x',
+                error: e && e.message ? e.message : 'Encoding failed'
+            }
+        }
+    }
+
+    private onAdd() {
+        const c = makeEmptyClause()
+        this.clauses.push(c)
+        this.activeId = c.id
+        this.markDirty()
+    }
+
+    private onRemove(id: string) {
+        const idx = this.clauses.findIndex(c => c.id === id)
+        if (idx === -1) return
+        this.clauses.splice(idx, 1)
+        if (this.activeId === id) {
+            const next = this.clauses[idx] || this.clauses[idx - 1] || null
+            this.activeId = next ? next.id : null
+        }
+        this.markDirty()
+    }
+
+    private onMove(payload: { id: string; delta: number }) {
+        const idx = this.clauses.findIndex(c => c.id === payload.id)
+        if (idx === -1) return
+        const newIdx = idx + payload.delta
+        if (newIdx < 0 || newIdx >= this.clauses.length) return
+        const [item] = this.clauses.splice(idx, 1)
+        this.clauses.splice(newIdx, 0, item)
+        this.markDirty()
+    }
+
+    private onSelect(id: string) {
+        this.activeId = id
+    }
+
+    private onUpdateClause(payload: { id: string; patch: Partial<Entities.TxBuilderClause> }) {
+        const idx = this.clauses.findIndex(c => c.id === payload.id)
+        if (idx === -1) return
+        const updated = { ...this.clauses[idx], ...payload.patch }
+        this.$set(this.clauses, idx, updated)
+        this.markDirty()
+    }
+
+    private markDirty() {
+        if (this.suppressDirty) return
+        this.dirty = true
+    }
+
+    private confirmReset() {
+        if (this.clauses.length === 0) return
+        const proceed = () => {
+            this.clauses = []
+            this.activeId = null
+            this.loadedDraftId = null
+            this.dirty = false
+        }
+        if (!this.dirty) {
+            proceed()
+            return
+        }
+        this.$buefy.dialog.confirm({
+            title: 'Discard workspace',
+            message: 'You have unsaved changes. Clear the workspace anyway?',
+            confirmText: 'Discard',
+            type: 'is-warning',
+            onConfirm: proceed
+        })
+    }
+
+    private onLoadDraft(d: Entities.TxBuilderDraft) {
+        const apply = () => {
+            this.suppressDirty = true
+            this.clauses = JSON.parse(JSON.stringify(d.clauses || []))
+            this.activeId = this.clauses.length > 0 ? this.clauses[0].id : null
+            this.loadedDraftId = d.id || null
+            this.dirty = false
+            this.$nextTick(() => { this.suppressDirty = false })
+        }
+        if (this.dirty && this.clauses.length > 0) {
+            this.$buefy.dialog.confirm({
+                title: 'Replace workspace',
+                message: 'You have unsaved changes. Load "' + d.name + '" anyway?',
+                confirmText: 'Load',
+                onConfirm: apply
+            })
+        } else {
+            apply()
+        }
+    }
+
+    private async onSaveDraft() {
+        if (!this.loadedDraftId) return
+        await DB.txBuilderDrafts.update(this.loadedDraftId, {
+            clauses: JSON.parse(JSON.stringify(this.clauses)),
+            updatedTime: Date.now()
+        })
+        this.dirty = false
+        this.$buefy.toast.open({ message: 'Draft saved', type: 'is-success', position: 'is-bottom' })
+    }
+
+    private onSaveAsDraft() {
+        if (this.clauses.length === 0) return
+        this.$buefy.dialog.prompt({
+            title: 'Save draft',
+            message: 'Give your draft a name (visible only on this network).',
+            inputAttrs: { placeholder: 'e.g. monthly payouts', maxlength: 60, required: true },
+            onConfirm: async (val: string) => {
+                const name = val.trim()
+                if (!name) return
+                const now = Date.now()
+                const id = await DB.txBuilderDrafts.add({
+                    name,
+                    network: this.network,
+                    clauses: JSON.parse(JSON.stringify(this.clauses)),
+                    createdTime: now,
+                    updatedTime: now
+                })
+                this.loadedDraftId = typeof id === 'number' ? id : null
+                this.dirty = false
+                this.$buefy.toast.open({ message: 'Draft saved', type: 'is-success', position: 'is-bottom' })
+            }
+        })
+    }
+
+    private onDraftDeleted(id: number) {
+        if (this.loadedDraftId === id) {
+            this.loadedDraftId = null
+        }
+    }
+
+    private onDraftRenamed(_: { id: number; name: string }) {
+        // no-op: drafts list reloads itself
+    }
+
+    private async submit() {
+        if (!this.canSubmit) return
+        const clauses = this.encodedClauses
+            .filter(e => e.isValid)
+            .map(e => ({ to: e.to, value: e.value, data: e.data, comment: e.comment || '' }))
+
+        if (clauses.length === 0) return
+        this.submitting = true
+        try {
+            const resp = await this.$connex.vendor
+                .sign('tx', clauses)
+                .comment('Inspector TX Builder')
+                .request()
+            if (resp && resp.txid) {
+                this.$buefy.toast.open({
+                    message: 'Transaction submitted',
+                    type: 'is-success',
+                    position: 'is-bottom'
+                })
+                window.open(`${this.$explorerTx}${resp.txid}`)
+            }
+        } catch (error: any) {
+            const msg = (error && error.message) || ''
+            const name = (error && error.name) || ''
+            const isUserRejection =
+                msg.toLowerCase().includes('rejected') ||
+                msg.toLowerCase().includes('cancel') ||
+                msg.toLowerCase().includes('denied') ||
+                name.toLowerCase().includes('rejected') ||
+                name.toLowerCase().includes('cancel')
+            if (!isUserRejection) {
+                this.$buefy.toast.open({
+                    message: `${name || 'Error'}: ${msg || 'Submission failed'}`,
+                    type: 'is-danger',
+                    position: 'is-bottom',
+                    duration: 4000
+                })
+            }
+        } finally {
+            this.submitting = false
+        }
+    }
+
+    @Watch('network')
+    private onNetworkChange() {
+        if (this.clauses.length === 0) return
+        this.$buefy.dialog.confirm({
+            title: 'Network changed',
+            message: 'Workspace clauses target the previous network. Clear them?',
+            confirmText: 'Clear',
+            type: 'is-warning',
+            canCancel: ['button'],
+            onConfirm: () => {
+                this.clauses = []
+                this.activeId = null
+                this.loadedDraftId = null
+                this.dirty = false
+            }
+        })
+    }
+
+    private created() {
+        window.scrollTo({ top: 0, left: 0 })
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.tx-builder-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: var(--body-background-alt);
+}
+
+.tx-builder-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 1.25rem;
+    background: var(--card-background);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.tx-builder-main {
+    flex: 1;
+    display: flex;
+    overflow: hidden;
+}
+
+.clause-list-pane {
+    width: 360px;
+    border-right: 1px solid var(--border-color);
+    background: var(--card-background);
+    overflow-y: auto;
+    flex-shrink: 0;
+}
+
+.clause-editor-pane {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.empty-state {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 2rem;
+    text-align: center;
+}
+.empty-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-color-strong);
+    margin: 0.5rem 0 0;
+}
+.empty-desc {
+    color: var(--text-color-light);
+    max-width: 360px;
+    margin-bottom: 0.75rem;
+}
+
+.tx-builder-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1.25rem;
+    background: var(--card-background);
+    border-top: 1px solid var(--border-color);
+}
+
+.footer-summary {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--text-color);
+}
+.summary-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: 14px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+.summary-pill.is-valid {
+    background: rgba(50, 175, 50, 0.12);
+    color: #228822;
+}
+.summary-pill.is-pending {
+    background: rgba(255, 165, 32, 0.12);
+    color: #b88010;
+}
+.summary-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+.is-pending .summary-dot {
+    animation: pulse 1.4s ease-in-out infinite;
+}
+.summary-aux {
+    font-size: 0.75rem;
+    color: var(--text-color-light);
+}
+
+.footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+@media (max-width: 768px) {
+    .tx-builder-main {
+        flex-direction: column;
+    }
+    .clause-list-pane {
+        width: 100%;
+        max-height: 40vh;
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
+    }
+}
+
+[data-theme="dark"] {
+    .summary-pill.is-valid {
+        background: rgba(80, 220, 80, 0.18);
+        color: #6be86b;
+    }
+    .summary-pill.is-pending {
+        background: rgba(255, 180, 30, 0.18);
+        color: #ffd766;
+    }
+}
+</style>

--- a/src/views/TxBuilder.vue
+++ b/src/views/TxBuilder.vue
@@ -127,27 +127,10 @@
             </div>
             <div class="footer-actions">
                 <button
-                    v-if="submission.status === 'confirmed'"
-                    type="button"
-                    class="button is-rounded is-primary"
-                    @click="dismissAndReset"
-                >
-                    Start new
-                </button>
-                <button
-                    v-else-if="submission.status !== 'submitting' && submission.status !== 'pending'"
                     type="button"
                     class="button is-rounded"
                     @click="dismissSubmission"
-                >
-                    Dismiss
-                </button>
-                <button
-                    v-else
-                    type="button"
-                    class="button is-rounded"
-                    @click="dismissSubmission"
-                    title="Stop tracking — the transaction will keep its course on-chain"
+                    :title="submission.status === 'submitting' || submission.status === 'pending' ? 'Stop tracking — the transaction will keep its course on-chain' : ''"
                 >
                     Hide
                 </button>
@@ -551,14 +534,6 @@ export default class TxBuilder extends Vue {
     private dismissSubmission() {
         this.stopReceiptPolling()
         this.submission = null
-    }
-
-    private dismissAndReset() {
-        this.dismissSubmission()
-        this.clauses = []
-        this.activeId = null
-        this.loadedDraftId = null
-        this.dirty = false
     }
 
     private beforeDestroy() {


### PR DESCRIPTION
## Summary

Adds a new **TX Builder** page (navbar entry · `/#/tx-builder`) for composing an ordered list of contract calls and signing them as a single VeChain transaction via `connex.vendor.sign('tx', clauses)`.

- Each clause picks a contract (from your library, the built-in registry, or inline manual ABI entry), a function, and parameters. View/pure functions are filtered out — they can't change state.
- Role-shaped `bytes32` params (e.g. `grantRole`, `revokeRole`, `renounceRole`) render a **RoleSelector** that discovers roles by scanning the contract ABI for role-getter shape (view/pure, 0 inputs, `bytes32` output, `UPPER_CASE` name), calls them on-chain, and caches per address for 7 days. Manual hex fallback is always available.
- Per-clause VET value supported when the function is payable, with VET/WEI toggle.
- Live encoding via the existing `account(addr).method(abi).value(hex).asClause(...params)` path. Invalid params (address, uint*, int*, bytes, bytesN) show inline red feedback.
- Workspace drafts persist per-network to a new Dexie store (`txBuilderDrafts`, schema v9). Save / save-as / rename / delete.
- Network change clears the workspace with a confirm.

https://github.com/user-attachments/assets/c3672ca5-36ce-4494-8058-8eb9bc283bb2


