### PR TITLE
fix: wait for Connex head before fetching role events

### DIFF
--- a/src/services/access-control-service.ts
+++ b/src/services/access-control-service.ts
@@ -84,6 +84,13 @@ export async function fetchRoleEvents(
   fromBlock?: number
 ): Promise<RoleEvent[]> {
   const account = connex.thor.account(contractAddress)
+
+  // Connex initializes head.number = 0 and updates it asynchronously after the
+  // first poll. If we read it before that update lands, the filter range
+  // collapses to {from: 0, to: 0} and returns no events. Wait one tick.
+  if (connex.thor.status.head.number === 0) {
+    await connex.thor.ticker().next()
+  }
   const currentBlock = connex.thor.status.head.number
 
   const range: Connex.Thor.Filter.Range = {


### PR DESCRIPTION
## Summary
- The Roles tab sometimes showed "No roles found for this contract." when opened quickly after page load, and only resolved after one or more refreshes.
- Root cause: Connex initializes `thor.status.head.number = 0` and updates it asynchronously after its first poll. When `RolesTab.mounted()` fired during that window, `fetchRoleEvents` built a filter range of `{from: 0, to: 0}`, so the node returned no events. The watcher on `contractAddress` doesn't re-fire on its own, so the empty state stuck.
- Fix: in `fetchRoleEvents`, if `head.number` is still `0`, await `connex.thor.ticker().next()` once before reading the head. Cost is zero when Connex is already warm.

## Test plan
- [ ] Hard refresh on a contract that has `RoleGranted` events, immediately click the Roles tab — roles populate on the first try
- [ ] Repeat across mainnet / testnet
- [ ] Switching between contracts after initial load still loads roles correctly (watcher path)
- [ ] Contract without AccessControl events still shows the empty state as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)