### PR TITLE
feat: Debugger page for tx forensics, signature lookup & address inspection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 <body class="has-navbar-fixed-top">
     <Navbar class="is-fixed-top" />
     <div class="router-view">
-        <keep-alive include="TxBuilder">
+        <keep-alive include="TxBuilder,Debugger">
             <router-view></router-view>
         </keep-alive>
     </div>

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -4,6 +4,7 @@ import NotSupport from './views/NotSupport.vue'
 import Contracts from './views/Contracts.vue'
 import Deploy from './views/DeployContract.vue'
 import TxBuilder from './views/TxBuilder.vue'
+import Debugger from './views/Debugger.vue'
 import ContractDetail from './views/ContractDetail.vue'
 import FilterView from './views/FilterView.vue'
 import FilterMgt from './views/FilterMgt.vue'
@@ -38,6 +39,11 @@ const router = new Router({
       name: 'tx_builder',
       component: TxBuilder,
       path: '/tx-builder'
+    },
+    {
+      name: 'debugger',
+      component: Debugger,
+      path: '/debugger'
     },
     {
       name: 'contract_detail',

--- a/src/components/Debugger/AddressInspectorPanel.vue
+++ b/src/components/Debugger/AddressInspectorPanel.vue
@@ -1,0 +1,783 @@
+<template>
+    <div class="address-panel">
+        <div v-if="loading" class="state-row">
+            <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+            <span>Inspecting address…</span>
+        </div>
+
+        <div v-else-if="error" class="error-state">
+            <b-icon icon="exclamation-triangle" custom-class="has-text-warning"></b-icon>
+            <span>{{ error }}</span>
+        </div>
+
+        <template v-else>
+            <!-- Header / live account data -->
+            <div class="card-block">
+                <div class="block-head">
+                    <span class="head-title">
+                        <b-icon :icon="hasCode ? 'file-code' : 'user'" size="is-small"></b-icon>
+                        {{ hasCode ? 'Contract' : 'EOA' }}
+                        <button class="help-btn" @click="openHelp('contract')" title="What is this?">
+                            <b-icon icon="question-circle" size="is-small"></b-icon>
+                        </button>
+                    </span>
+                    <a :href="$explorerAccount + value" target="_blank" rel="noopener" class="external-link">
+                        View on explorer
+                        <b-icon icon="external-link-alt" size="is-small"></b-icon>
+                    </a>
+                </div>
+
+                <div class="kv-grid">
+                    <div class="kv-row">
+                        <span class="kv-key">Address</span>
+                        <code class="kv-val is-family-monospace">{{ value }}</code>
+                    </div>
+                    <div v-if="registryHit" class="kv-row">
+                        <span class="kv-key">Known as</span>
+                        <span class="kv-val">{{ registryHit.name }}</span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">VET</span>
+                        <span class="kv-val">{{ formatWei(account.balance) }}</span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">VTHO</span>
+                        <span class="kv-val">{{ formatWei(account.energy) }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Bytecode summary -->
+            <div v-if="hasCode" class="card-block">
+                <div class="block-head">
+                    <span class="head-title">
+                        Bytecode
+                        <button class="help-btn" @click="openHelp('bytecode')" title="What is this?">
+                            <b-icon icon="question-circle" size="is-small"></b-icon>
+                        </button>
+                    </span>
+                </div>
+                <div class="kv-grid">
+                    <div class="kv-row">
+                        <span class="kv-key">Size</span>
+                        <span class="kv-val">{{ codeByteLength.toLocaleString() }} bytes</span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">ERC interfaces</span>
+                        <span class="kv-val">
+                            <span v-if="ercSniff.length === 0" class="tag-pill is-muted">none detected</span>
+                            <span
+                                v-for="tag in ercSniff"
+                                :key="tag"
+                                class="tag-pill"
+                            >{{ tag }}</span>
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Proxy detection -->
+            <div v-if="hasCode" class="card-block">
+                <div class="block-head">
+                    <span class="head-title">
+                        Proxy detection (EIP-1967)
+                        <button class="help-btn" @click="openHelp('proxy')" title="What is this?">
+                            <b-icon icon="question-circle" size="is-small"></b-icon>
+                        </button>
+                    </span>
+                </div>
+                <div v-if="!proxy.isProxy" class="empty-mini">
+                    No EIP-1967 slots populated — this likely isn't a transparent / UUPS proxy.
+                </div>
+                <template v-else>
+                    <div class="kv-grid">
+                        <div v-if="proxy.implementation" class="kv-row">
+                            <span class="kv-key">Implementation</span>
+                            <code class="kv-val is-family-monospace">{{ proxy.implementation }}</code>
+                        </div>
+                        <div v-if="proxy.admin" class="kv-row">
+                            <span class="kv-key">Admin</span>
+                            <code class="kv-val is-family-monospace">{{ proxy.admin }}</code>
+                        </div>
+                        <div v-if="proxy.beacon" class="kv-row">
+                            <span class="kv-key">Beacon</span>
+                            <code class="kv-val is-family-monospace">{{ proxy.beacon }}</code>
+                        </div>
+                    </div>
+                </template>
+            </div>
+
+            <!-- Registry hit summary -->
+            <div v-if="registryHit && abiSummary" class="card-block">
+                <div class="block-head">
+                    <span class="head-title">
+                        Imported ABI
+                        <button class="help-btn" @click="openHelp('abi')" title="What is this?">
+                            <b-icon icon="question-circle" size="is-small"></b-icon>
+                        </button>
+                    </span>
+                    <span class="source-pill" :class="sourcePillClass">{{ sourceLabel }}</span>
+                </div>
+
+                <div
+                    v-if="sourcedAbi && sourcedAbi.implAddress"
+                    class="impl-note"
+                >
+                    <b-icon icon="link" size="is-small" class="impl-icon"></b-icon>
+                    <div class="impl-note-text">
+                        <span class="impl-note-key">ABI fetched via implementation</span>
+                        <code class="impl-note-addr is-family-monospace">{{ sourcedAbi.implAddress }}</code>
+                        <span class="impl-note-aside">
+                            (this address is a proxy; Sourcify verifies the impl, not the proxy wrapper)
+                        </span>
+                    </div>
+                </div>
+
+                <div class="kv-grid">
+                    <div class="kv-row">
+                        <span class="kv-key">Functions</span>
+                        <span class="kv-val">{{ abiSummary.functions }}</span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Events</span>
+                        <span class="kv-val">{{ abiSummary.events }}</span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Errors</span>
+                        <span class="kv-val">{{ abiSummary.errors }}</span>
+                    </div>
+                    <div v-if="sourcedAbi" class="kv-row">
+                        <span class="kv-key">Fetched</span>
+                        <span class="kv-val">{{ formatTimestamp(sourcedAbi.fetchedTime) }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- No ABI available -->
+            <div v-else-if="hasCode" class="card-block">
+                <div class="block-head">
+                    <span class="head-title">
+                        ABI
+                        <button class="help-btn" @click="openHelp('abi-missing')" title="Why is this missing?">
+                            <b-icon icon="question-circle" size="is-small"></b-icon>
+                        </button>
+                    </span>
+                    <span class="source-pill is-muted">unknown</span>
+                </div>
+                <div class="empty-mini">
+                    No ABI available. Inspect the bytecode and proxy slots above, or import the ABI manually via the Contracts page to enable decoding.
+                </div>
+            </div>
+        </template>
+
+        <!-- Contextual help modal -->
+        <b-modal :active.sync="helpActive" has-modal-card trap-focus :on-cancel="closeHelp">
+            <div class="modal-card help-modal" v-if="helpEntry">
+                <header class="modal-card-head">
+                    <p class="modal-card-title">{{ helpEntry.title }}</p>
+                    <button type="button" class="delete" @click="closeHelp" aria-label="Close"></button>
+                </header>
+                <section class="modal-card-body">
+                    <div class="help-body" v-html="helpEntry.body"></div>
+                </section>
+                <footer class="modal-card-foot">
+                    <button type="button" class="button" @click="closeHelp">Close</button>
+                </footer>
+            </div>
+        </b-modal>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import DB, { Entities } from '../../database'
+import { loadAllContracts, ensureAbisForAddresses, findContractByAddress } from '../../utils/abi-registry'
+import { getAccount, getAccountCode, getStorage, AccountInfo } from '../../services/debug-service'
+
+// EIP-1967 storage slots.
+const SLOT_IMPL = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
+const SLOT_ADMIN = '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
+const SLOT_BEACON = '0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50'
+
+// 4-byte function selectors used to sniff ERC standards. We just substring-match
+// these against bytecode — the Solidity dispatcher emits each selector as
+// PUSH4 literal bytes, so this catches typical compiled contracts.
+const ERC20_SELECTORS = [
+    '18160ddd', // totalSupply()
+    '70a08231', // balanceOf(address)
+    'a9059cbb', // transfer(address,uint256)
+    '23b872dd', // transferFrom(address,address,uint256)
+    '095ea7b3', // approve(address,uint256)
+    'dd62ed3e'  // allowance(address,address)
+]
+const ERC721_SELECTORS = [
+    '6352211e', // ownerOf(uint256)
+    'b88d4fde', // safeTransferFrom(address,address,uint256,bytes)
+    'a22cb465', // setApprovalForAll(address,bool)
+    'e985e9c5'  // isApprovedForAll(address,address)
+]
+
+type AbiSource = 'imported' | 'builtin' | 'sourcify' | 'unknown'
+
+function slotToAddress(slotValue: string): string | null {
+    // Storage word is 32 bytes; an address sits in the low 20 bytes.
+    if (!slotValue || !slotValue.startsWith('0x')) return null
+    const hex = slotValue.slice(2).padStart(64, '0')
+    const addr = '0x' + hex.slice(24)
+    if (/^0x0+$/.test(addr)) return null
+    return addr
+}
+
+@Component({ name: 'AddressInspectorPanel' })
+export default class AddressInspectorPanel extends Vue {
+    @Prop({ type: String, required: true }) value!: string
+
+    private loading: boolean = false
+    private error: string = ''
+    private account: AccountInfo = { balance: '0x0', energy: '0x0', hasCode: false }
+    private code: string = '0x'
+    private proxy: { isProxy: boolean; implementation: string | null; admin: string | null; beacon: string | null } = {
+        isProxy: false,
+        implementation: null,
+        admin: null,
+        beacon: null
+    }
+    private registryHit: Entities.Contract | null = null
+    private importedHit: Entities.Contract | null = null
+    private sourcedAbi: Entities.SourcedAbi | null = null
+    private helpKey: string | null = null
+
+    get helpActive(): boolean {
+        return this.helpKey !== null
+    }
+    set helpActive(v: boolean) {
+        if (!v) this.helpKey = null
+    }
+
+    get helpEntry(): { title: string; body: string } | null {
+        if (!this.helpKey) return null
+        const entries: Record<string, { title: string; body: string }> = {
+            contract: {
+                title: 'Contract vs EOA',
+                body: `
+                    <p>Live account state pulled from the connected node.</p>
+                    <ul>
+                        <li><strong>Contract</strong> — the address has deployed bytecode and can execute logic when called.</li>
+                        <li><strong>EOA</strong> (Externally Owned Account) — a regular wallet with no code. Can sign transactions but not be called like a contract.</li>
+                    </ul>
+                    <p>VET and VTHO balances are the current on-chain values.</p>
+                `
+            },
+            bytecode: {
+                title: 'Bytecode & ERC sniff',
+                body: `
+                    <p><strong>Size</strong> is the length of the deployed runtime bytecode at this address.</p>
+                    <p><strong>ERC interface detection</strong> works by substring-matching the standard 4-byte function selectors against the bytecode. Solidity's dispatcher emits each function selector as a literal <code>PUSH4</code> instruction, so common implementations are easy to recognize.</p>
+                    <p>This is a heuristic only:</p>
+                    <ul>
+                        <li>Contracts using delegatecall fallbacks (proxies, diamonds) won't have the impl's selectors in their own bytecode.</li>
+                        <li>Non-standard dispatchers (e.g. assembly-coded contracts) can slip through.</li>
+                    </ul>
+                `
+            },
+            proxy: {
+                title: 'EIP-1967 proxy detection',
+                body: `
+                    <p>The Debugger reads three reserved storage slots defined by
+                    <a href="https://eips.ethereum.org/EIPS/eip-1967" target="_blank" rel="noopener">EIP-1967</a>
+                    directly from the node:</p>
+                    <ul>
+                        <li><strong>Implementation</strong> — the address where the logic actually lives. If this slot is non-zero, the address is almost certainly an OpenZeppelin transparent or UUPS upgradeable proxy.</li>
+                        <li><strong>Admin</strong> — the address allowed to upgrade the proxy (transparent proxies only).</li>
+                        <li><strong>Beacon</strong> — for beacon-based proxies, the beacon contract that resolves the impl.</li>
+                    </ul>
+                    <p>To decode calls against the proxy you need the <strong>implementation's</strong> ABI — the Debugger tries to fetch it from Sourcify automatically when you inspect a proxy address.</p>
+                `
+            },
+            abi: {
+                title: 'Where this ABI came from',
+                body: this.abiSourceLongHelp()
+            },
+            'abi-missing': {
+                title: 'Why is there no ABI?',
+                body: `
+                    <p>We checked three sources and found nothing for this contract:</p>
+                    <ul>
+                        <li><strong>User-imported</strong> — no entry in your local IndexedDB <code>contracts</code> table.</li>
+                        <li><strong>Built-in (b32)</strong> — not part of the vechain/b32 registry that ships with the app.</li>
+                        <li><strong>Sourcify</strong> — either the contract isn't verified there, or the request didn't return metadata.</li>
+                    </ul>
+                    <p>You can still inspect the bytecode and proxy slots. To decode calls / events / errors against this contract, import the ABI manually via the Contracts page.</p>
+                `
+            }
+        }
+        return entries[this.helpKey] || null
+    }
+
+    private abiSourceLongHelp(): string {
+        switch (this.abiSource) {
+            case 'imported':
+                return `
+                    <p><strong>Source: user-imported.</strong></p>
+                    <p>This ABI was added via the Contracts page (by you or someone using this browser profile). User imports always win over built-in or Sourcify ABIs for the same address.</p>
+                    <p>To replace it, edit or delete the contract from the Contracts page and reload.</p>
+                `
+            case 'builtin':
+                return `
+                    <p><strong>Source: built-in registry (vechain/b32).</strong></p>
+                    <p>This ABI ships with the app via the <a href="https://github.com/vechain/b32" target="_blank" rel="noopener">vechain/b32</a> registry — Authority/VTHO/Prototype, VeBetterDAO contracts, StarGate, ERC-20/721, and a handful of ecosystem projects.</p>
+                    <p>Updates land when the b32 repo cuts a new release and we sync. If you need a newer ABI in the meantime, import the JSON manually.</p>
+                `
+            case 'sourcify':
+                if (this.sourcedAbi && this.sourcedAbi.implAddress) {
+                    return `
+                        <p><strong>Source: Sourcify (verified) — fetched via the implementation contract.</strong></p>
+                        <p>This address is a proxy. The Debugger:</p>
+                        <ol>
+                            <li>Read the EIP-1967 implementation slot from on-chain storage.</li>
+                            <li>Looked up the implementation address (<code>${this.sourcedAbi.implAddress}</code>) on Sourcify.</li>
+                            <li>Pulled the verified ABI from the impl's metadata.</li>
+                            <li>Stored it locally under <em>this</em> (proxy) address so future inspections are instant.</li>
+                        </ol>
+                        <p>This is why decoding works against the proxy even though Sourcify only verifies the impl.</p>
+                    `
+                }
+                return `
+                    <p><strong>Source: Sourcify (verified).</strong></p>
+                    <p>Pulled directly from Sourcify's verified contract record for this address. The ABI is persisted locally in the <code>sourcedAbis</code> IndexedDB table so future inspections are instant.</p>
+                `
+            default:
+                return ''
+        }
+    }
+
+    private openHelp(key: string) {
+        this.helpKey = key
+    }
+
+    private closeHelp() {
+        this.helpKey = null
+    }
+
+    get hasCode(): boolean {
+        return !!this.account && this.account.hasCode
+    }
+
+    get codeByteLength(): number {
+        if (!this.code || this.code === '0x') return 0
+        return (this.code.length - 2) / 2
+    }
+
+    get ercSniff(): string[] {
+        if (!this.hasCode || !this.code) return []
+        const lower = this.code.toLowerCase()
+        const has = (sel: string) => lower.indexOf(sel) !== -1
+        const tags: string[] = []
+        if (ERC20_SELECTORS.every(has)) tags.push('ERC-20')
+        if (ERC721_SELECTORS.every(has)) tags.push('ERC-721')
+        return tags
+    }
+
+    get abiSummary(): { functions: number; events: number; errors: number } | null {
+        if (!this.registryHit) return null
+        const abi = this.registryHit.abi
+        if (!Array.isArray(abi)) return null
+        let f = 0
+        let e = 0
+        let er = 0
+        for (const item of abi) {
+            if (!item || typeof item !== 'object') continue
+            const t = (item as any).type
+            if (t === 'function') f++
+            else if (t === 'event') e++
+            else if (t === 'error') er++
+        }
+        return { functions: f, events: e, errors: er }
+    }
+
+    get abiSource(): AbiSource {
+        if (!this.registryHit) return 'unknown'
+        if (this.importedHit) return 'imported'
+        if (this.sourcedAbi) return 'sourcify'
+        return 'builtin'
+    }
+
+    get sourceLabel(): string {
+        switch (this.abiSource) {
+            case 'imported': return 'user-imported'
+            case 'builtin':  return 'built-in (b32)'
+            case 'sourcify': return 'sourcify (verified)'
+            default:         return 'unknown'
+        }
+    }
+
+    get sourcePillClass(): string {
+        return 'is-' + this.abiSource
+    }
+
+    private formatWei(hexWei: string): string {
+        try {
+            const bn = BN(hexWei || '0')
+            return bn.dividedBy(1e18).toFormat(4)
+        } catch {
+            return hexWei
+        }
+    }
+
+    private formatTimestamp(ts: number | undefined): string {
+        if (!ts) return ''
+        const d = new Date(ts)
+        return d.toLocaleString()
+    }
+
+    private async lookupSourcedAbi(genesisId: string, address: string) {
+        try {
+            const hit = await DB.sourcedAbis
+                .where('[genesisId+address]')
+                .equals([genesisId, address.toLowerCase()])
+                .first()
+            this.sourcedAbi = hit || null
+        } catch {
+            this.sourcedAbi = null
+        }
+    }
+
+    private async lookupImportedAbi(address: string) {
+        try {
+            const hit = await DB.contracts
+                .filter((c) => (c.address || '').toLowerCase() === address.toLowerCase())
+                .first()
+            this.importedHit = hit || null
+        } catch {
+            this.importedHit = null
+        }
+    }
+
+    private async load() {
+        this.loading = true
+        this.error = ''
+        this.registryHit = null
+        this.importedHit = null
+        this.sourcedAbi = null
+        this.code = '0x'
+        this.proxy = { isProxy: false, implementation: null, admin: null, beacon: null }
+        try {
+            const genesisId = this.$connex.thor.genesis.id
+            const [account, code, contracts] = await Promise.all([
+                getAccount(this.$nodeUrl, this.value),
+                getAccountCode(this.$nodeUrl, this.value),
+                loadAllContracts(genesisId)
+            ])
+            this.account = account
+            this.code = code || '0x'
+            this.registryHit = findContractByAddress(contracts, this.value)
+
+            // If we don't know this contract locally, try Sourcify silently.
+            if (!this.registryHit && account.hasCode) {
+                const refreshed = await ensureAbisForAddresses(genesisId, [this.value], this.$nodeUrl)
+                this.registryHit = findContractByAddress(refreshed, this.value)
+            }
+
+            // Provenance lookups (independent of registryHit resolution above).
+            await Promise.all([
+                this.lookupImportedAbi(this.value),
+                this.lookupSourcedAbi(genesisId, this.value)
+            ])
+
+            if (account.hasCode) {
+                const [implSlot, adminSlot, beaconSlot] = await Promise.all([
+                    getStorage(this.$nodeUrl, this.value, SLOT_IMPL).catch(() => ''),
+                    getStorage(this.$nodeUrl, this.value, SLOT_ADMIN).catch(() => ''),
+                    getStorage(this.$nodeUrl, this.value, SLOT_BEACON).catch(() => '')
+                ])
+                const impl = slotToAddress(implSlot)
+                const admin = slotToAddress(adminSlot)
+                const beacon = slotToAddress(beaconSlot)
+                this.proxy = {
+                    isProxy: !!(impl || beacon),
+                    implementation: impl,
+                    admin,
+                    beacon
+                }
+            }
+        } catch (e: any) {
+            this.error = e && e.message ? e.message : 'Failed to inspect address.'
+        } finally {
+            this.loading = false
+        }
+    }
+
+    @Watch('value', { immediate: true })
+    private onValueChange() {
+        this.load()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.address-panel {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.state-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-color-light);
+    padding: 1.5rem;
+    justify-content: center;
+}
+
+.error-state {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 165, 32, 0.1);
+    border: 1px solid rgba(255, 165, 32, 0.3);
+    border-radius: 6px;
+    color: var(--text-color);
+    font-size: 0.9rem;
+}
+
+.card-block {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+}
+
+.block-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid var(--border-color);
+}
+.head-title {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    color: var(--text-color);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.external-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--primary-color);
+    text-decoration: none;
+    font-size: 0.8rem;
+}
+.external-link:hover {
+    text-decoration: underline;
+}
+
+.help-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-color-light);
+    cursor: pointer;
+    padding: 0 0 0 0.25rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    transition: color 0.15s ease;
+}
+.help-btn:hover {
+    color: var(--primary-color);
+}
+.help-btn:focus {
+    outline: none;
+    color: var(--primary-color);
+}
+
+::v-deep .help-modal .modal-card {
+    max-width: 540px;
+    width: 100%;
+    background: var(--card-background);
+}
+::v-deep .help-modal .modal-card-head,
+::v-deep .help-modal .modal-card-foot {
+    background: var(--card-background);
+    border-color: var(--border-color);
+}
+::v-deep .help-modal .modal-card-title {
+    color: var(--text-color);
+    font-size: 1rem;
+}
+::v-deep .help-modal .modal-card-body {
+    background: var(--card-background);
+    color: var(--text-color);
+}
+::v-deep .help-modal .help-body {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--text-color);
+}
+::v-deep .help-modal .help-body p {
+    margin: 0 0 0.75rem 0;
+}
+::v-deep .help-modal .help-body p:last-child {
+    margin-bottom: 0;
+}
+::v-deep .help-modal .help-body ul,
+::v-deep .help-modal .help-body ol {
+    margin: 0 0 0.75rem 1.25rem;
+    padding: 0;
+    color: var(--text-color-light);
+}
+::v-deep .help-modal .help-body li {
+    margin-bottom: 0.35rem;
+}
+::v-deep .help-modal .help-body strong {
+    color: var(--text-color);
+    font-weight: 600;
+}
+::v-deep .help-modal .help-body code {
+    font-size: 0.8rem;
+    color: var(--text-color);
+}
+::v-deep .help-modal .help-body a {
+    color: var(--primary-color);
+}
+
+.source-pill {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.18rem 0.55rem;
+    border-radius: 10px;
+}
+.source-pill.is-imported {
+    background: rgba(50, 175, 50, 0.14);
+    color: #228822;
+}
+.source-pill.is-builtin {
+    background: rgba(50, 115, 220, 0.14);
+    color: var(--primary-color);
+}
+.source-pill.is-sourcify {
+    background: rgba(127, 86, 217, 0.18);
+    color: #7f56d9;
+}
+.source-pill.is-muted,
+.source-pill.is-unknown {
+    background: var(--code-bg);
+    color: var(--text-color-light);
+}
+
+.impl-note {
+    display: flex;
+    gap: 0.55rem;
+    align-items: flex-start;
+    padding: 0.6rem 0.75rem;
+    border: 1px solid rgba(127, 86, 217, 0.25);
+    background: rgba(127, 86, 217, 0.06);
+    border-radius: 6px;
+    margin-bottom: 0.75rem;
+}
+.impl-icon {
+    color: #7f56d9;
+    flex-shrink: 0;
+    margin-top: 0.15rem;
+}
+.impl-note-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.8rem;
+}
+.impl-note-key {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #7f56d9;
+}
+.impl-note-addr {
+    color: var(--text-color);
+    word-break: break-all;
+    font-size: 0.82rem;
+}
+.impl-note-aside {
+    color: var(--text-color-light);
+    font-size: 0.75rem;
+}
+
+.kv-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem 1.5rem;
+}
+.kv-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    font-size: 0.85rem;
+    min-width: 0;
+}
+.kv-key {
+    color: var(--text-color-light);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    flex-shrink: 0;
+    width: 110px;
+}
+.kv-val {
+    color: var(--text-color);
+    word-break: break-all;
+    min-width: 0;
+}
+
+.tag-pill {
+    display: inline-block;
+    background: rgba(50, 175, 50, 0.12);
+    color: #228822;
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    margin-right: 0.3rem;
+}
+.tag-pill.is-muted {
+    background: var(--code-bg);
+    color: var(--text-color-light);
+}
+
+.empty-mini {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+    padding: 0.4rem 0;
+    font-style: italic;
+}
+
+.aside {
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+}
+.aside em {
+    color: var(--text-color);
+    font-style: normal;
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .kv-grid {
+        grid-template-columns: 1fr;
+    }
+}
+</style>

--- a/src/components/Debugger/AddressInspectorPanel.vue
+++ b/src/components/Debugger/AddressInspectorPanel.vue
@@ -73,6 +73,13 @@
                             >{{ tag }}</span>
                         </span>
                     </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Shape</span>
+                        <span class="kv-val">
+                            <span v-if="isLikelyLibrary" class="tag-pill is-library">possible library</span>
+                            <span v-else class="tag-pill is-muted">regular contract</span>
+                        </span>
+                    </div>
                 </div>
             </div>
 
@@ -151,6 +158,36 @@
                         <span class="kv-val">{{ formatTimestamp(sourcedAbi.fetchedTime) }}</span>
                     </div>
                 </div>
+
+                <div class="abi-actions">
+                    <button
+                        v-if="abiSource !== 'imported'"
+                        type="button"
+                        class="button is-small is-primary is-outlined"
+                        @click="addToMyContracts"
+                    >
+                        <b-icon icon="plus" size="is-small"></b-icon>
+                        <span>Add to my contracts</span>
+                    </button>
+                    <button
+                        type="button"
+                        class="button is-small is-light"
+                        @click="showAbi = !showAbi"
+                    >
+                        <b-icon :icon="showAbi ? 'eye-slash' : 'eye'" size="is-small"></b-icon>
+                        <span>{{ showAbi ? 'Hide ABI' : 'View ABI' }}</span>
+                    </button>
+                    <button
+                        type="button"
+                        class="button is-small is-light"
+                        @click="copyAbi"
+                    >
+                        <b-icon icon="copy" size="is-small"></b-icon>
+                        <span>Copy</span>
+                    </button>
+                </div>
+
+                <pre v-if="showAbi" class="abi-display"><code class="is-family-monospace">{{ abiJson }}</code></pre>
             </div>
 
             <!-- No ABI available -->
@@ -193,6 +230,7 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
 import DB, { Entities } from '../../database'
 import { loadAllContracts, ensureAbisForAddresses, findContractByAddress } from '../../utils/abi-registry'
 import { getAccount, getAccountCode, getStorage, AccountInfo } from '../../services/debug-service'
+import EditContract from '../EditContract.vue'
 
 // EIP-1967 storage slots.
 const SLOT_IMPL = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
@@ -246,6 +284,7 @@ export default class AddressInspectorPanel extends Vue {
     private importedHit: Entities.Contract | null = null
     private sourcedAbi: Entities.SourcedAbi | null = null
     private helpKey: string | null = null
+    private showAbi: boolean = false
 
     get helpActive(): boolean {
         return this.helpKey !== null
@@ -378,6 +417,31 @@ export default class AddressInspectorPanel extends Vue {
         return tags
     }
 
+    // Heuristic: Solidity emits a library address check at the very start of
+    // a library's bytecode — `PUSH20 <self-address>` (opcode 0x73) followed by
+    // an address-equality check that rejects non-DELEGATECALL invocations.
+    // If we find PUSH20 + this address within the first ~100 bytes of code,
+    // this is most likely a library deployment. Not 100% reliable but covers
+    // standard `library Foo { ... }` Solidity output.
+    get isLikelyLibrary(): boolean {
+        if (!this.hasCode || !this.code) return false
+        const addrHex = this.value.toLowerCase().replace(/^0x/, '')
+        if (addrHex.length !== 40) return false
+        const lowerCode = this.code.toLowerCase()
+        const pattern = '73' + addrHex
+        const head = lowerCode.slice(0, 250) // ~125 bytes
+        return head.includes(pattern)
+    }
+
+    get abiJson(): string {
+        if (!this.registryHit || !Array.isArray(this.registryHit.abi)) return ''
+        try {
+            return JSON.stringify(this.registryHit.abi, null, 2)
+        } catch {
+            return ''
+        }
+    }
+
     get abiSummary(): { functions: number; events: number; errors: number } | null {
         if (!this.registryHit) return null
         const abi = this.registryHit.abi
@@ -428,6 +492,74 @@ export default class AddressInspectorPanel extends Vue {
         if (!ts) return ''
         const d = new Date(ts)
         return d.toLocaleString()
+    }
+
+    private async copyAbi() {
+        if (!this.abiJson) return
+        try {
+            await navigator.clipboard.writeText(this.abiJson)
+        } catch {
+            try {
+                const ta = document.createElement('textarea')
+                ta.value = this.abiJson
+                ta.setAttribute('readonly', '')
+                ta.style.position = 'absolute'
+                ta.style.left = '-9999px'
+                document.body.appendChild(ta)
+                ta.select()
+                document.execCommand('copy')
+                document.body.removeChild(ta)
+            } catch { return }
+        }
+        ;(this as any).$buefy.toast.open({
+            message: 'ABI copied',
+            type: 'is-success',
+            position: 'is-bottom',
+            duration: 1500
+        })
+    }
+
+    private addToMyContracts() {
+        if (!this.registryHit) return
+        const prefill: Entities.Contract = {
+            name: this.registryHit.name || '',
+            address: this.value,
+            abi: this.registryHit.abi as any,
+            category: ''
+        }
+        // $buefy.modal.open doesn't auto-close when the inner component emits
+        // its own `cancel` / `finished` events — only on the modal's own
+        // cancellation (escape, outside-click, ×). EditContract emits cancel
+        // and finished but doesn't tell the modal to close, so we have to
+        // close it ourselves via the returned instance.
+        let modal: any = null
+        modal = (this as any).$buefy.modal.open({
+            parent: this,
+            component: EditContract,
+            hasModalCard: true,
+            trapFocus: true,
+            canCancel: ['escape', 'outside'],
+            props: {
+                item: prefill,
+                isImport: false
+            },
+            events: {
+                cancel: () => {
+                    if (modal) modal.close()
+                },
+                finished: () => {
+                    if (modal) modal.close()
+                    ;(this as any).$buefy.toast.open({
+                        message: `Added "${prefill.name || prefill.address.slice(0, 10) + '…'}" to your contracts`,
+                        type: 'is-success',
+                        position: 'is-bottom',
+                        duration: 2500
+                    })
+                    // Re-run lookup so the panel reflects the new "user-imported" source.
+                    this.load()
+                }
+            }
+        })
     }
 
     private async lookupSourcedAbi(genesisId: string, address: string) {
@@ -755,6 +887,37 @@ export default class AddressInspectorPanel extends Vue {
 .tag-pill.is-muted {
     background: var(--code-bg);
     color: var(--text-color-light);
+}
+.tag-pill.is-library {
+    background: rgba(127, 86, 217, 0.18);
+    color: #7f56d9;
+}
+
+.abi-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.85rem;
+    flex-wrap: wrap;
+}
+
+.abi-display {
+    margin-top: 0.85rem;
+    background: var(--code-bg);
+    color: var(--text-color);
+    padding: 0.75rem 0.9rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    max-height: 360px;
+    overflow: auto;
+    white-space: pre;
+    border: 1px solid var(--border-color);
+}
+.abi-display code {
+    background: transparent;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
 }
 
 .empty-mini {

--- a/src/components/Debugger/CalldataDecoderPanel.vue
+++ b/src/components/Debugger/CalldataDecoderPanel.vue
@@ -1,0 +1,271 @@
+<template>
+    <div class="lookup-panel">
+        <div class="lookup-header">
+            <div class="header-label">Calldata</div>
+            <div class="header-value is-family-monospace">{{ value }}</div>
+            <div class="header-aux">
+                <span class="aux-pill">selector <code>{{ selector }}</code></span>
+                <span class="aux-pill">{{ argsByteLength }} bytes of args</span>
+            </div>
+        </div>
+
+        <div v-if="loading" class="state-row">
+            <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+            <span>Searching imported / built-in contracts and the b32 keccak DB…</span>
+        </div>
+
+        <div v-else-if="!decoded && !b32Decoded" class="empty">
+            <b-icon icon="search-minus" size="is-medium" custom-class="has-text-grey-light"></b-icon>
+            <p class="empty-title">Couldn't decode</p>
+            <p class="empty-desc">
+                The leading selector <code>{{ selector }}</code> doesn't match any function in your imported contracts, the built-in registry, or the b32 keccak database.
+            </p>
+        </div>
+
+        <div v-else class="results">
+            <template v-if="decoded">
+                <div class="canonical-row">
+                    <span class="canonical-label">Function</span>
+                    <code class="canonical-name">{{ decoded.canonicalName }}</code>
+                    <span class="canonical-contract">on {{ decoded.contract.name }}</span>
+                    <span class="source-pill is-registry">registry</span>
+                </div>
+
+                <div v-if="decoded.args.length" class="inputs-block">
+                    <div class="inputs-label">Decoded arguments</div>
+                    <ul class="arg-list">
+                        <li v-for="(a, i) in decoded.args" :key="i" class="arg-row">
+                            <span class="arg-type">{{ a.type }}</span>
+                            <span class="arg-name">{{ a.name }}</span>
+                            <code class="arg-value is-family-monospace">{{ formatArg(a.value) }}</code>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="empty-mini">(no arguments)</div>
+            </template>
+
+            <template v-else-if="b32Decoded">
+                <div class="canonical-row">
+                    <span class="canonical-label">Function</span>
+                    <code class="canonical-name">{{ b32Decoded.canonicalName }}</code>
+                    <span
+                        class="source-pill"
+                        :class="b32Decoded.source === 'openchain' ? 'is-openchain' : 'is-b32'"
+                    >{{ b32Decoded.source === 'openchain' ? 'openchain (cross-chain)' : 'b32 keccak DB' }}</span>
+                </div>
+
+                <div v-if="b32Decoded.args.length" class="inputs-block">
+                    <div class="inputs-label">Decoded arguments</div>
+                    <ul class="arg-list">
+                        <li v-for="(a, i) in b32Decoded.args" :key="i" class="arg-row">
+                            <span class="arg-type">{{ a.type }}</span>
+                            <span class="arg-name">{{ a.name }}</span>
+                            <code class="arg-value is-family-monospace">{{ formatArg(a.value) }}</code>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="empty-mini">(no arguments)</div>
+
+                <p v-if="b32Decoded.source === 'openchain'" class="aside">
+                    Matched via OpenChain's cross-chain signature database (covers Ethereum and many other EVM chains). Useful for VeChain contracts that are forks of Ethereum protocols. Parameter names aren't preserved by the canonical signature.
+                </p>
+                <p v-else class="aside">
+                    Matched via the b32 keccak signature database — we know the function's name and parameter types but not which contract defines it.
+                </p>
+            </template>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { abi } from 'thor-devkit'
+import { loadAllContracts, decodeCalldata, DecodedCall } from '../../utils/abi-registry'
+import { fetchSignature, canonicalSignature } from '../../services/b32-service'
+import {
+    fetchSignature as fetchOpenChainSignature,
+    signatureToFunctionItem
+} from '../../services/openchain-service'
+
+interface DecodedFromB32 {
+    canonicalName: string
+    args: Array<{ name: string; type: string; value: any }>
+    source: 'b32' | 'openchain'
+}
+
+@Component({ name: 'CalldataDecoderPanel' })
+export default class CalldataDecoderPanel extends Vue {
+    @Prop({ type: String, required: true }) value!: string
+
+    private decoded: DecodedCall | null = null
+    private b32Decoded: DecodedFromB32 | null = null
+    private loading: boolean = false
+
+    get selector(): string {
+        return this.value.slice(0, 10)
+    }
+
+    get argsByteLength(): number {
+        return Math.max(0, (this.value.length - 10) / 2)
+    }
+
+    private formatArg(v: any): string {
+        if (v === null || v === undefined) return ''
+        if (typeof v === 'string') return v
+        if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+        if (typeof v === 'bigint') return v.toString()
+        if (Array.isArray(v)) return '[' + v.map((x) => this.formatArg(x)).join(', ') + ']'
+        if (v && typeof v.toString === 'function') return v.toString()
+        return JSON.stringify(v)
+    }
+
+    private decodeWithAbiItem(item: any, source: 'b32' | 'openchain'): DecodedFromB32 | null {
+        if (!item || item.type !== 'function') return null
+        const inputs = Array.isArray(item.inputs) ? item.inputs : []
+        const argsHex = '0x' + this.value.slice(10)
+        try {
+            const decoded = inputs.length
+                ? abi.decodeParameters(inputs as any, argsHex)
+                : ({} as any)
+            return {
+                canonicalName: canonicalSignature(item),
+                args: inputs.map((inp: any, i: number) => ({
+                    name: inp.name || `arg${i}`,
+                    type: inp.type,
+                    value: decoded[i]
+                })),
+                source
+            }
+        } catch {
+            return null
+        }
+    }
+
+    private async runLookup() {
+        this.loading = true
+        this.decoded = null
+        this.b32Decoded = null
+        try {
+            const contracts = await loadAllContracts(this.$connex.thor.genesis.id)
+            this.decoded = decodeCalldata(contracts, null, this.value)
+            if (!this.decoded) {
+                const sig = await fetchSignature(this.selector)
+                if (sig && sig.item) {
+                    this.b32Decoded = this.decodeWithAbiItem(sig.item, 'b32')
+                }
+                if (!this.b32Decoded) {
+                    const oc = await fetchOpenChainSignature('function', this.selector)
+                    if (oc && oc.canonicalSignature) {
+                        const item = signatureToFunctionItem(oc.canonicalSignature)
+                        if (item) this.b32Decoded = this.decodeWithAbiItem(item, 'openchain')
+                    }
+                }
+            }
+        } finally {
+            this.loading = false
+        }
+    }
+
+    @Watch('value', { immediate: true })
+    private onValueChange() {
+        this.runLookup()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+@import './lookup-panel.scss';
+
+.header-aux {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+}
+.aux-pill {
+    font-size: 0.72rem;
+    color: var(--text-color-light);
+    background: var(--code-bg);
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+}
+.aux-pill code {
+    font-size: 0.72rem;
+}
+
+.canonical-contract {
+    color: var(--text-color-light);
+    font-size: 0.8rem;
+}
+
+.source-pill {
+    display: inline-block;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    margin-left: 0.5rem;
+}
+.source-pill.is-registry {
+    background: rgba(50, 115, 220, 0.14);
+    color: var(--primary-color);
+}
+.source-pill.is-b32 {
+    background: rgba(255, 165, 32, 0.16);
+    color: #b88010;
+}
+.source-pill.is-openchain {
+    background: rgba(20, 184, 166, 0.18);
+    color: #0d9488;
+}
+
+.aside {
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+}
+
+.arg-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.arg-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.35rem 0;
+    font-size: 0.82rem;
+    border-bottom: 1px dashed var(--border-color);
+    flex-wrap: wrap;
+}
+.arg-row:last-child {
+    border-bottom: none;
+}
+.arg-type {
+    color: var(--text-color);
+    font-weight: 600;
+    font-family: monospace;
+    font-size: 0.78rem;
+}
+.arg-name {
+    color: var(--text-color-light);
+    font-family: monospace;
+    font-size: 0.78rem;
+}
+.arg-value {
+    color: var(--text-color);
+    word-break: break-all;
+    font-size: 0.8rem;
+    flex: 1;
+}
+.empty-mini {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+    padding: 0.4rem 0;
+    font-style: italic;
+}
+</style>

--- a/src/components/Debugger/InternalTraceSection.vue
+++ b/src/components/Debugger/InternalTraceSection.vue
@@ -1,0 +1,532 @@
+<template>
+    <div class="card-block">
+        <div class="block-head">
+            <span class="head-title">
+                Internal trace
+                <button class="help-btn" @click="helpOpen = true" title="How do I read this?">
+                    <b-icon icon="question-circle" size="is-small"></b-icon>
+                </button>
+            </span>
+            <button
+                v-if="!loading && !loaded && !unavailable"
+                type="button"
+                class="button is-small"
+                @click="load"
+            >
+                Load trace
+            </button>
+            <button
+                v-else-if="loaded && !unavailable"
+                type="button"
+                class="button is-small is-light"
+                @click="load"
+            >
+                Reload
+            </button>
+        </div>
+
+        <div v-if="loading" class="state-row">
+            <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+            <span>Tracing clauses…</span>
+        </div>
+
+        <div v-else-if="unavailable" class="warning-box">
+            <b-icon icon="info-circle" custom-class="has-text-warning"></b-icon>
+            <div>
+                <strong>Tracer endpoint unavailable on this node.</strong>
+                <div class="warning-aux">
+                    Internal call traces come from <code>POST /debug/tracers</code>, which most public nodes leave disabled.
+                    Run a self-hosted Thor instance with <code>--api-allowed-tracers all</code> (or your network's equivalent) to enable it.
+                </div>
+            </div>
+        </div>
+
+        <div v-else-if="error" class="warning-box">
+            <b-icon icon="exclamation-triangle" custom-class="has-text-warning"></b-icon>
+            <span>{{ error }}</span>
+        </div>
+
+        <div v-else-if="loaded">
+            <div v-if="!frames.length" class="empty-mini">No trace data returned.</div>
+            <div v-for="(entry, i) in frames" :key="i" class="trace-clause">
+                <div class="trace-clause-head">
+                    <span class="clause-tag">clause #{{ entry.clauseIndex }}</span>
+                    <span v-if="entry.error" class="clause-err">{{ entry.error }}</span>
+                </div>
+
+                <TraceFrame
+                    v-if="entry.frame"
+                    :frame="entry.frame"
+                    :contracts="contracts"
+                    :extra-signatures="extraSignatures"
+                    :depth="0"
+                />
+                <div v-else class="empty-mini">No frame available for this clause.</div>
+            </div>
+        </div>
+
+        <div v-else class="hint">
+            Trace is loaded on demand. Tap "Load trace" — large transactions may take a moment.
+        </div>
+
+        <b-modal :active.sync="helpOpen" has-modal-card trap-focus>
+            <div class="modal-card help-modal">
+                <header class="modal-card-head">
+                    <p class="modal-card-title">How to read the internal trace</p>
+                    <button type="button" class="delete" @click="helpOpen = false" aria-label="Close"></button>
+                </header>
+                <section class="modal-card-body">
+                    <div class="help-body">
+                        <p>
+                            The trace is the actual EVM call tree from the failing transaction, fetched via
+                            <code>POST /debug/tracers</code> on the connected node. Each row is one EVM frame —
+                            a call, delegatecall, staticcall, or contract creation.
+                        </p>
+
+                        <p><strong>Row anatomy</strong></p>
+                        <pre class="help-pre">▼ [CALL]  90,257  Contract.method(arg = value) =&gt; result  0xabc…123</pre>
+                        <ul>
+                            <li><strong>▼ / ▶</strong> — expand or collapse this frame's children. Click anywhere on the row to toggle.</li>
+                            <li><strong>Type chip</strong> — colour-coded EVM operation:
+                                <ul>
+                                    <li><span class="legend is-call">CALL</span> regular external call</li>
+                                    <li><span class="legend is-static">STATICCALL</span> read-only call (no state changes allowed)</li>
+                                    <li><span class="legend is-delegate">DELEGATECALL</span> proxy-style call that executes target's code in the caller's storage context</li>
+                                    <li><span class="legend is-create">CREATE</span> / <span class="legend is-create">CREATE2</span> contract deployment</li>
+                                </ul>
+                            </li>
+                            <li><strong>Gas</strong> — gas consumed by this frame (right-aligned column).</li>
+                            <li><strong>Decoded call</strong> — <code>Contract.method(arg = value)</code> when we have an ABI for the target, otherwise the raw 4-byte selector. Return value follows <code>=&gt;</code> when the function has typed outputs we can decode. Addresses inside args resolve to contract names if known.</li>
+                            <li><strong>Address chip</strong> at the end — the target address of this frame. For DELEGATECALL chains this is the impl address; the storage context stays with the outer caller.</li>
+                            <li><strong>Red frames</strong> — this call failed. The right edge shows the specific error (<code>execution reverted</code>, <code>out of gas</code>, …). The red left border traces the failure path up the tree.</li>
+                        </ul>
+
+                        <p><strong>Reading a revert</strong></p>
+                        <p>
+                            For a Solidity <code>require()</code> / <code>revert(CustomError)</code>, the revert data
+                            propagates from the failing frame up to the top — the outer frame's output decodes to the
+                            same revert. The Revert reason card above this one already shows that decoded version.
+                        </p>
+                        <p>
+                            For EVM-level halts (<code>out of gas</code>, invalid opcode), only the failing frame
+                            shows the cause — outer frames just see "call returned 0". Walk down the red border to
+                            find the originating frame.
+                        </p>
+
+                        <p><strong>Tip</strong></p>
+                        <p>
+                            Frames are collapsed past depth 2 by default to keep the initial view readable. Errored
+                            frames always start expanded so the failure path is visible.
+                        </p>
+                    </div>
+                </section>
+                <footer class="modal-card-foot">
+                    <button type="button" class="button" @click="helpOpen = false">Close</button>
+                </footer>
+            </div>
+        </b-modal>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Entities } from '../../database'
+import { ensureAbisForAddresses, decodeCalldata } from '../../utils/abi-registry'
+import {
+    isTracerAvailable,
+    traceClauseCall,
+    getBlock,
+    TraceCallFrame
+} from '../../services/debug-service'
+import { fetchSignature as fetchB32Signature } from '../../services/b32-service'
+import {
+    fetchSignatures as fetchOpenChainSignatures,
+    signatureToFunctionItem
+} from '../../services/openchain-service'
+import TraceFrame from './TraceFrame.vue'
+
+interface ClauseTraceEntry {
+    clauseIndex: number
+    frame: TraceCallFrame | null
+    error: string | null
+}
+
+@Component({
+    components: { TraceFrame }
+})
+export default class InternalTraceSection extends Vue {
+    @Prop({ type: Object, required: true }) tx!: Connex.Thor.Transaction
+    @Prop({ type: Object, required: true }) receipt!: Connex.Thor.Transaction.Receipt
+    @Prop({ type: Array, required: true }) contracts!: Entities.Contract[]
+
+    private loading: boolean = false
+    private loaded: boolean = false
+    private unavailable: boolean = false
+    private error: string = ''
+    private frames: ClauseTraceEntry[] = []
+    private helpOpen: boolean = false
+    // selector → { item: AbiItem, source: 'b32' | 'openchain' }, populated
+    // for frame inputs the local registry can't decode.
+    private extraSignatures: Record<string, { item: any; source: 'b32' | 'openchain' }> = {}
+
+    private collectFrameAddresses(frame: TraceCallFrame, into: Set<string>) {
+        if (frame.to && /^0x[0-9a-fA-F]{40}$/.test(frame.to)) {
+            into.add(frame.to.toLowerCase())
+        }
+        if (frame.calls) {
+            for (const child of frame.calls) {
+                this.collectFrameAddresses(child, into)
+            }
+        }
+    }
+
+    private collectFrameSelectors(
+        frame: TraceCallFrame,
+        contracts: Entities.Contract[],
+        into: Set<string>
+    ) {
+        if (frame.input && frame.input.length >= 10) {
+            // Only collect selectors we can't already decode locally.
+            if (!decodeCalldata(contracts, frame.to || null, frame.input)) {
+                into.add(frame.input.slice(0, 10).toLowerCase())
+            }
+        }
+        if (frame.calls) {
+            for (const child of frame.calls) {
+                this.collectFrameSelectors(child, contracts, into)
+            }
+        }
+    }
+
+    private async enrichTraceAddresses(entries: ClauseTraceEntry[]) {
+        const addrs = new Set<string>()
+        for (const entry of entries) {
+            if (entry.frame) this.collectFrameAddresses(entry.frame, addrs)
+        }
+
+        // Step 1: Sourcify enrichment for addresses (impls in delegatecall
+        // chains, helper contracts, etc.)
+        let refreshed = this.contracts
+        if (addrs.size > 0) {
+            try {
+                refreshed = await ensureAbisForAddresses(
+                    this.$connex.thor.genesis.id,
+                    Array.from(addrs),
+                    this.$nodeUrl
+                )
+                if (refreshed.length !== this.contracts.length) {
+                    this.$emit('contracts-updated', refreshed)
+                }
+            } catch {
+                // silent — Sourcify is best-effort
+            }
+        }
+
+        // Step 2: signature DB enrichment for selectors the refreshed registry
+        // still can't decode. b32 first (per-selector files; parallel), then
+        // OpenChain (one batched HTTP request for the leftovers). Results
+        // are merged into a local map and committed to extraSignatures in
+        // one assignment so all frames decode together rather than flickering
+        // in one by one.
+        const selectors = new Set<string>()
+        for (const entry of entries) {
+            if (entry.frame) this.collectFrameSelectors(entry.frame, refreshed, selectors)
+        }
+        if (selectors.size === 0) return
+
+        const pending: Record<string, { item: any; source: 'b32' | 'openchain' }> = {}
+
+        // b32: one file per selector (cached locally including misses), so
+        // we fire them in parallel.
+        const b32Results = await Promise.all(
+            Array.from(selectors).map(async (sel) => {
+                const b32 = await fetchB32Signature(sel)
+                if (b32 && b32.item && b32.item.type === 'function') {
+                    return [sel, b32.item] as [string, any]
+                }
+                return null
+            })
+        )
+        const b32Hits = new Set<string>()
+        for (const r of b32Results) {
+            if (!r) continue
+            pending[r[0]] = { item: r[1], source: 'b32' }
+            b32Hits.add(r[0])
+        }
+
+        // OpenChain: batch the leftovers. One HTTP request (chunked to 50)
+        // resolves them all instead of N round-trips.
+        const leftover = Array.from(selectors).filter((s) => !b32Hits.has(s))
+        if (leftover.length > 0) {
+            const ocMap = await fetchOpenChainSignatures('function', leftover)
+            for (const [sel, sig] of ocMap.entries()) {
+                if (!sig.canonicalSignature) continue
+                const item = signatureToFunctionItem(sig.canonicalSignature)
+                if (item) pending[sel] = { item, source: 'openchain' }
+            }
+        }
+
+        // Single reactive commit — replaces the whole map so Vue's reactivity
+        // fires once. All frames re-decode at the same moment.
+        if (Object.keys(pending).length > 0) {
+            this.extraSignatures = { ...this.extraSignatures, ...pending }
+        }
+    }
+
+    private async load() {
+        this.loading = true
+        this.error = ''
+        this.frames = []
+        this.unavailable = false
+        try {
+            // Probe availability with a deliberately invalid target — a 400
+            // means "endpoint up, bad input", which is what we want.
+            const sampleTarget = `${this.receipt.meta.blockID}/0/0`
+            const available = await isTracerAvailable(this.$nodeUrl, sampleTarget)
+            if (!available) {
+                this.unavailable = true
+                return
+            }
+
+            // Find this tx's index inside its block.
+            const block = await getBlock(this.$nodeUrl, this.receipt.meta.blockID)
+            if (!block) {
+                this.error = 'Could not load the containing block.'
+                return
+            }
+            const txIndex = block.transactions.findIndex(
+                (id) => id.toLowerCase() === this.tx.id.toLowerCase()
+            )
+            if (txIndex === -1) {
+                this.error = 'Transaction not found in its block.'
+                return
+            }
+
+            // Trace each clause independently. Continue on per-clause failure
+            // so partial results are still useful.
+            const entries: ClauseTraceEntry[] = []
+            for (let i = 0; i < this.tx.clauses.length; i++) {
+                try {
+                    const frame = await traceClauseCall(
+                        this.$nodeUrl,
+                        this.receipt.meta.blockID,
+                        txIndex,
+                        i
+                    )
+                    entries.push({ clauseIndex: i, frame, error: null })
+                } catch (e: any) {
+                    entries.push({
+                        clauseIndex: i,
+                        frame: null,
+                        error: e && e.message ? e.message : 'Trace failed.'
+                    })
+                }
+            }
+            this.frames = entries
+            this.loaded = true
+
+            // Trace frames typically reach impls / helper contracts that the
+            // top-level tx never touches directly. Pull their ABIs from
+            // Sourcify (proxy-aware) so decoding lights up across the page.
+            this.enrichTraceAddresses(entries)
+        } catch (e: any) {
+            this.error = e && e.message ? e.message : 'Failed to load trace.'
+        } finally {
+            this.loading = false
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.card-block {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+}
+
+.block-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid var(--border-color);
+}
+.head-title {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+.state-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-color-light);
+    padding: 0.4rem 0;
+    font-size: 0.9rem;
+}
+
+.warning-box {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 165, 32, 0.08);
+    border: 1px solid rgba(255, 165, 32, 0.25);
+    border-radius: 6px;
+    color: var(--text-color);
+    font-size: 0.85rem;
+}
+.warning-box strong {
+    color: var(--text-color);
+    font-weight: 600;
+}
+.warning-aux {
+    margin-top: 0.25rem;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+}
+.warning-aux code {
+    color: var(--text-color);
+}
+
+.empty-mini {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+    padding: 0.4rem 0;
+    font-style: italic;
+}
+
+.hint {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+}
+
+.trace-clause {
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.6rem 0.7rem;
+    background: var(--code-bg);
+    margin-bottom: 0.5rem;
+}
+.trace-clause:last-child {
+    margin-bottom: 0;
+}
+.trace-clause-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.clause-tag {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    padding: 0.1rem 0.45rem;
+    border-radius: 10px;
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    font-weight: 600;
+}
+.clause-err {
+    color: #d8294d;
+    font-size: 0.8rem;
+}
+
+.help-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-color-light);
+    cursor: pointer;
+    padding: 0 0 0 0.25rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    transition: color 0.15s ease;
+}
+.help-btn:hover,
+.help-btn:focus {
+    outline: none;
+    color: var(--primary-color);
+}
+
+::v-deep .help-modal .modal-card {
+    max-width: 620px;
+    width: 100%;
+    background: var(--card-background);
+}
+::v-deep .help-modal .modal-card-head,
+::v-deep .help-modal .modal-card-foot {
+    background: var(--card-background);
+    border-color: var(--border-color);
+}
+::v-deep .help-modal .modal-card-title {
+    color: var(--text-color);
+    font-size: 1rem;
+}
+::v-deep .help-modal .modal-card-body {
+    background: var(--card-background);
+    color: var(--text-color);
+}
+::v-deep .help-modal .help-body {
+    font-size: 0.88rem;
+    line-height: 1.55;
+    color: var(--text-color);
+}
+::v-deep .help-modal .help-body p {
+    margin: 0 0 0.75rem 0;
+}
+::v-deep .help-modal .help-body p:last-child {
+    margin-bottom: 0;
+}
+::v-deep .help-modal .help-body ul {
+    margin: 0 0 0.85rem 1.25rem;
+    padding: 0;
+    color: var(--text-color-light);
+}
+::v-deep .help-modal .help-body ul ul {
+    margin-top: 0.3rem;
+    margin-bottom: 0;
+}
+::v-deep .help-modal .help-body li {
+    margin-bottom: 0.35rem;
+}
+::v-deep .help-modal .help-body strong {
+    color: var(--text-color);
+    font-weight: 600;
+}
+::v-deep .help-modal .help-body code {
+    font-size: 0.8rem;
+    color: var(--text-color);
+}
+::v-deep .help-modal .help-body .help-pre {
+    font-family: monospace;
+    font-size: 0.78rem;
+    background: var(--code-bg);
+    padding: 0.5rem 0.7rem;
+    border-radius: 4px;
+    color: var(--text-color);
+    margin: 0 0 0.85rem 0;
+    overflow-x: auto;
+}
+::v-deep .help-modal .help-body .legend {
+    display: inline-block;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.08rem 0.4rem;
+    border-radius: 3px;
+    margin: 0 0.15rem;
+    vertical-align: middle;
+}
+::v-deep .help-modal .help-body .legend.is-call     { background: rgba(50, 115, 220, 0.18); color: var(--primary-color); }
+::v-deep .help-modal .help-body .legend.is-static   { background: rgba(50, 175, 50, 0.18); color: #228822; }
+::v-deep .help-modal .help-body .legend.is-delegate { background: rgba(255, 165, 32, 0.18); color: #b88010; }
+::v-deep .help-modal .help-body .legend.is-create   { background: rgba(127, 86, 217, 0.22); color: #7f56d9; }
+</style>

--- a/src/components/Debugger/SelectorLookupPanel.vue
+++ b/src/components/Debugger/SelectorLookupPanel.vue
@@ -1,0 +1,178 @@
+<template>
+    <div class="lookup-panel">
+        <div class="lookup-header">
+            <div class="header-label">Function selector</div>
+            <div class="header-value is-family-monospace">{{ value }}</div>
+        </div>
+
+        <div v-if="loading" class="state-row">
+            <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+            <span>Searching imported / built-in contracts and the b32 keccak DB…</span>
+        </div>
+
+        <div v-else-if="hits.length === 0 && !b32Item" class="empty">
+            <b-icon icon="search-minus" size="is-medium" custom-class="has-text-grey-light"></b-icon>
+            <p class="empty-title">No match found</p>
+            <p class="empty-desc">
+                Searched your imported contracts, the built-in registry, and the b32 keccak signature database. Import the contract that defines this function, then try again.
+            </p>
+        </div>
+
+        <div v-else class="results">
+            <div class="canonical-row">
+                <span class="canonical-label">Function signature</span>
+                <code class="canonical-name">{{ canonicalName }}</code>
+                <span class="source-pill" :class="sourcePillClass">{{ sourceLabel }}</span>
+            </div>
+
+            <div class="inputs-block" v-if="displayInputs.length">
+                <div class="inputs-label">Parameters</div>
+                <ul class="inputs-list">
+                    <li v-for="(inp, i) in displayInputs" :key="i">
+                        <span class="arg-type">{{ inp.type }}</span>
+                        <span class="arg-name">{{ inp.name || `arg${i}` }}</span>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="meta-row" v-if="stateMutability">
+                <span class="meta-key">State mutability</span>
+                <span class="meta-val">{{ stateMutability }}</span>
+            </div>
+
+            <div v-if="hits.length" class="contracts-block">
+                <div class="contracts-label">
+                    Found in {{ hits.length }} contract{{ hits.length === 1 ? '' : 's' }}
+                </div>
+                <ul class="contracts-list">
+                    <li v-for="(hit, i) in hits" :key="i" class="contract-row">
+                        <span class="contract-name">{{ hit.contract.name }}</span>
+                        <code class="contract-address is-family-monospace">{{ hit.contract.address }}</code>
+                    </li>
+                </ul>
+            </div>
+
+            <p v-else-if="b32Item" class="aside">
+                Matched via the b32 keccak signature database. No imported contract claims this selector — to attribute it to a specific contract, import that contract's ABI on the Contracts page.
+            </p>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { loadAllContracts, lookupBySelector, FunctionHit } from '../../utils/abi-registry'
+import { fetchSignature, canonicalSignature } from '../../services/b32-service'
+import {
+    fetchSignature as fetchOpenChainSignature,
+    signatureToFunctionItem
+} from '../../services/openchain-service'
+
+@Component({ name: 'SelectorLookupPanel' })
+export default class SelectorLookupPanel extends Vue {
+    @Prop({ type: String, required: true }) value!: string
+
+    private hits: FunctionHit[] = []
+    private b32Item: any | null = null
+    private loading: boolean = false
+
+    get canonicalName(): string {
+        if (this.hits.length) return this.hits[0].canonicalName
+        if (this.b32Item) return canonicalSignature(this.b32Item)
+        return ''
+    }
+
+    get displayInputs(): Array<{ name: string; type: string }> {
+        if (this.hits.length) {
+            return this.hits[0].definition.inputs as any
+        }
+        if (this.b32Item && Array.isArray(this.b32Item.inputs)) {
+            return this.b32Item.inputs as any
+        }
+        return []
+    }
+
+    get stateMutability(): string {
+        if (this.hits.length) return this.hits[0].definition.stateMutability || ''
+        if (this.b32Item) return this.b32Item.stateMutability || ''
+        return ''
+    }
+
+    get sourceLabel(): string {
+        if (this.hits.length) return 'registry'
+        if (this.b32Item && (this.b32Item as any)._openchain) return 'openchain (cross-chain)'
+        if (this.b32Item) return 'b32 keccak DB'
+        return ''
+    }
+
+    get sourcePillClass(): string {
+        if (this.hits.length) return 'is-registry'
+        if (this.b32Item && (this.b32Item as any)._openchain) return 'is-openchain'
+        if (this.b32Item) return 'is-b32'
+        return ''
+    }
+
+    private async runLookup() {
+        this.loading = true
+        this.hits = []
+        this.b32Item = null
+        try {
+            const contracts = await loadAllContracts(this.$connex.thor.genesis.id)
+            this.hits = lookupBySelector(contracts, this.value)
+            if (this.hits.length === 0) {
+                const sig = await fetchSignature(this.value)
+                if (sig && sig.item && (sig.item.type === 'function' || !sig.item.type)) {
+                    this.b32Item = sig.item
+                } else {
+                    // Final fallback: OpenChain cross-chain signature DB.
+                    const oc = await fetchOpenChainSignature('function', this.value)
+                    if (oc && oc.canonicalSignature) {
+                        const item = signatureToFunctionItem(oc.canonicalSignature)
+                        if (item) this.b32Item = { ...item, _openchain: true }
+                    }
+                }
+            }
+        } finally {
+            this.loading = false
+        }
+    }
+
+    @Watch('value', { immediate: true })
+    private onValueChange() {
+        this.runLookup()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+@import './lookup-panel.scss';
+
+.source-pill {
+    display: inline-block;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    margin-left: 0.5rem;
+}
+.source-pill.is-registry {
+    background: rgba(50, 115, 220, 0.14);
+    color: var(--primary-color);
+}
+.source-pill.is-b32 {
+    background: rgba(255, 165, 32, 0.16);
+    color: #b88010;
+}
+.source-pill.is-openchain {
+    background: rgba(20, 184, 166, 0.18);
+    color: #0d9488;
+}
+
+.aside {
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+}
+</style>

--- a/src/components/Debugger/Topic0LookupPanel.vue
+++ b/src/components/Debugger/Topic0LookupPanel.vue
@@ -1,0 +1,172 @@
+<template>
+    <div class="lookup-panel">
+        <div class="lookup-header">
+            <div class="header-label">Event topic0</div>
+            <div class="header-value is-family-monospace">{{ value }}</div>
+        </div>
+
+        <div v-if="loading" class="state-row">
+            <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+            <span>Searching imported / built-in contracts and the b32 keccak DB…</span>
+        </div>
+
+        <div v-else-if="hits.length === 0 && !b32Item" class="empty">
+            <b-icon icon="search-minus" size="is-medium" custom-class="has-text-grey-light"></b-icon>
+            <p class="empty-title">No match found</p>
+            <p class="empty-desc">
+                Searched your imported contracts, the built-in registry, and the b32 keccak signature database. Import the contract that emits this event, then try again.
+            </p>
+        </div>
+
+        <div v-else class="results">
+            <div class="canonical-row">
+                <span class="canonical-label">Event signature</span>
+                <code class="canonical-name">{{ canonicalName }}</code>
+                <span class="source-pill" :class="sourcePillClass">{{ sourceLabel }}</span>
+            </div>
+
+            <div class="inputs-block" v-if="displayInputs.length">
+                <div class="inputs-label">Arguments</div>
+                <ul class="inputs-list">
+                    <li v-for="(inp, i) in displayInputs" :key="i">
+                        <span v-if="inp.indexed" class="indexed-badge">indexed</span>
+                        <span class="arg-type">{{ inp.type }}</span>
+                        <span class="arg-name">{{ inp.name || `arg${i}` }}</span>
+                    </li>
+                </ul>
+            </div>
+
+            <div v-if="hits.length" class="contracts-block">
+                <div class="contracts-label">
+                    Found in {{ hits.length }} contract{{ hits.length === 1 ? '' : 's' }}
+                </div>
+                <ul class="contracts-list">
+                    <li v-for="(hit, i) in hits" :key="i" class="contract-row">
+                        <span class="contract-name">{{ hit.contract.name }}</span>
+                        <code class="contract-address is-family-monospace">{{ hit.contract.address }}</code>
+                    </li>
+                </ul>
+            </div>
+
+            <p v-else-if="b32Item" class="aside">
+                Matched via the b32 keccak signature database. No imported contract owns this event — to attribute it to a specific contract, import that contract's ABI on the Contracts page.
+            </p>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { loadAllContracts, lookupByTopic0, EventHit } from '../../utils/abi-registry'
+import { fetchSignature, canonicalSignature } from '../../services/b32-service'
+import {
+    fetchSignature as fetchOpenChainSignature,
+    signatureToEventItem
+} from '../../services/openchain-service'
+
+@Component({ name: 'Topic0LookupPanel' })
+export default class Topic0LookupPanel extends Vue {
+    @Prop({ type: String, required: true }) value!: string
+
+    private hits: EventHit[] = []
+    private b32Item: any | null = null
+    private loading: boolean = false
+
+    get canonicalName(): string {
+        if (this.hits.length) return this.hits[0].canonicalName
+        if (this.b32Item) return canonicalSignature(this.b32Item)
+        return ''
+    }
+
+    get displayInputs(): Array<{ name: string; type: string; indexed?: boolean }> {
+        if (this.hits.length) {
+            return this.hits[0].definition.inputs as any
+        }
+        if (this.b32Item && Array.isArray(this.b32Item.inputs)) {
+            return this.b32Item.inputs as any
+        }
+        return []
+    }
+
+    get sourceLabel(): string {
+        if (this.hits.length) return 'registry'
+        if (this.b32Item && (this.b32Item as any)._openchain) return 'openchain (cross-chain)'
+        if (this.b32Item) return 'b32 keccak DB'
+        return ''
+    }
+
+    get sourcePillClass(): string {
+        if (this.hits.length) return 'is-registry'
+        if (this.b32Item && (this.b32Item as any)._openchain) return 'is-openchain'
+        if (this.b32Item) return 'is-b32'
+        return ''
+    }
+
+    private async runLookup() {
+        this.loading = true
+        this.hits = []
+        this.b32Item = null
+        try {
+            const contracts = await loadAllContracts(this.$connex.thor.genesis.id)
+            this.hits = lookupByTopic0(contracts, this.value)
+            if (this.hits.length === 0) {
+                const sig = await fetchSignature(this.value)
+                if (sig && sig.item && (sig.item.type === 'event' || !sig.item.type)) {
+                    this.b32Item = sig.item
+                } else {
+                    // Final fallback: OpenChain cross-chain signature DB. We
+                    // don't know how many params are indexed without a live
+                    // log, so render the canonical signature without indexed
+                    // badges. Decoding happens elsewhere (tx forensics) when
+                    // we have a log to count topics from.
+                    const oc = await fetchOpenChainSignature('event', this.value)
+                    if (oc && oc.canonicalSignature) {
+                        const item = signatureToEventItem(oc.canonicalSignature, 0)
+                        if (item) this.b32Item = { ...item, _openchain: true }
+                    }
+                }
+            }
+        } finally {
+            this.loading = false
+        }
+    }
+
+    @Watch('value', { immediate: true })
+    private onValueChange() {
+        this.runLookup()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+@import './lookup-panel.scss';
+
+.source-pill {
+    display: inline-block;
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.15rem 0.5rem;
+    border-radius: 10px;
+    margin-left: 0.5rem;
+}
+.source-pill.is-registry {
+    background: rgba(50, 115, 220, 0.14);
+    color: var(--primary-color);
+}
+.source-pill.is-b32 {
+    background: rgba(255, 165, 32, 0.16);
+    color: #b88010;
+}
+.source-pill.is-openchain {
+    background: rgba(20, 184, 166, 0.18);
+    color: #0d9488;
+}
+
+.aside {
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+}
+</style>

--- a/src/components/Debugger/TraceFrame.vue
+++ b/src/components/Debugger/TraceFrame.vue
@@ -1,0 +1,531 @@
+<template>
+    <div class="trace-frame" :class="{ 'is-errored': hasError }">
+        <div class="frame-row" @click="toggleExpanded">
+            <button
+                type="button"
+                class="chevron"
+                :class="{ 'is-empty': !hasChildren }"
+                @click.stop="toggleExpanded"
+                :aria-label="expanded ? 'Collapse' : 'Expand'"
+            >
+                <b-icon
+                    v-if="hasChildren"
+                    :icon="expanded ? 'chevron-down' : 'chevron-right'"
+                    size="is-small"
+                ></b-icon>
+            </button>
+
+            <span class="type-chip" :class="typeClass">{{ frame.type }}</span>
+
+            <span v-if="gasLabel" class="gas-label">{{ gasLabel }}</span>
+
+            <span class="call-text">
+                <template v-if="decoded">
+                    <span class="contract-name">{{ decoded.contract.name }}</span><span class="dot">.</span><span class="fn-name">{{ decoded.fnName }}</span>(<span class="args-inline">{{ inputsInline }}</span>)<template v-if="returnInline">
+                        <span class="arrow"> =&gt; </span><span class="output-inline">{{ returnInline }}</span>
+                    </template>
+                </template>
+                <template v-else-if="frame.to">
+                    <span class="contract-name">{{ targetName || shortAddr(frame.to) }}</span><template v-if="rawSelector">.<span class="fn-name is-raw">{{ rawSelector }}</span></template>
+                </template>
+                <template v-else>
+                    <span class="contract-name">(contract creation)</span>
+                </template>
+            </span>
+
+
+            <span
+                v-if="frame.to"
+                class="frame-addr"
+                :title="frame.to + ' — click to copy'"
+                @click.stop.prevent="copyAddress($event)"
+                @mousedown.stop
+                @mouseup.stop
+            >
+                <code class="is-family-monospace addr-text">{{ shortAddr(frame.to) }}</code>
+                <b-icon icon="copy" size="is-small" custom-class="copy-icon"></b-icon>
+            </span>
+
+            <span v-if="valueLabel" class="value-label">{{ valueLabel }}</span>
+
+            <span v-if="hasError" class="error-tag">{{ frame.error || 'reverted' }}</span>
+        </div>
+
+        <div v-if="expanded && (showInputDetail || showOutputDetail || frame.revertReason)" class="frame-extras">
+            <div v-if="showInputDetail" class="extra-row">
+                <span class="extra-key">input</span>
+                <code class="extra-val is-family-monospace">{{ truncated(frame.input) }}</code>
+            </div>
+            <div v-if="showOutputDetail" class="extra-row">
+                <span class="extra-key">output</span>
+                <code class="extra-val is-family-monospace">{{ truncated(frame.output) }}</code>
+            </div>
+            <div v-if="frame.revertReason" class="extra-row is-revert">
+                <span class="extra-key">revert</span>
+                <code class="extra-val is-family-monospace">{{ frame.revertReason }}</code>
+            </div>
+        </div>
+
+        <div v-if="expanded && hasChildren" class="frame-children">
+            <TraceFrame
+                v-for="(child, i) in frame.calls"
+                :key="i"
+                :frame="child"
+                :contracts="contracts"
+                :extra-signatures="extraSignatures"
+                :depth="depth + 1"
+            />
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Entities } from '../../database'
+import {
+    findContractByAddress,
+    decodeFrameCall,
+    decodeCalldataWithAbiItem,
+    DecodedFrameCall,
+    DecodedCall
+} from '../../utils/abi-registry'
+import { TraceCallFrame } from '../../services/debug-service'
+
+interface ExtraSig { item: any; source: 'b32' | 'openchain' }
+
+@Component({ name: 'TraceFrame' })
+export default class TraceFrame extends Vue {
+    @Prop({ type: Object, required: true }) frame!: TraceCallFrame
+    @Prop({ type: Array, required: true }) contracts!: Entities.Contract[]
+    @Prop({ type: Object, default: () => ({}) }) extraSignatures!: Record<string, ExtraSig>
+    @Prop({ type: Number, default: 0 }) depth!: number
+
+    private expanded: boolean = this.shouldDefaultExpand()
+
+    get decoded(): DecodedFrameCall | null {
+        if (!this.frame.input || this.frame.input === '0x') return null
+        const local = decodeFrameCall(this.contracts, this.frame.to || null, this.frame.input, this.frame.output)
+        if (local) return local
+
+        // Fall back to b32 / OpenChain signature DBs. We get input args but no
+        // output type info — render outputs as raw bytes via the existing
+        // showOutputDetail path.
+        const selector = this.frame.input.slice(0, 10).toLowerCase()
+        const extra = this.extraSignatures[selector]
+        if (!extra) return null
+        const decodedCall: DecodedCall | null = decodeCalldataWithAbiItem(this.frame.input, extra.item)
+        if (!decodedCall) return null
+        // Reshape DecodedCall into DecodedFrameCall — same fields plus an
+        // empty outputs array (we don't have typed return data from sig DBs).
+        return {
+            fnName: decodedCall.fnName,
+            canonicalName: decodedCall.canonicalName,
+            contract: {
+                name: this.frameContractLabel(),
+                address: this.frame.to || ''
+            },
+            inputs: decodedCall.args,
+            outputs: null
+        }
+    }
+
+    get decodedSource(): 'registry' | 'b32' | 'openchain' {
+        if (!this.frame.input || this.frame.input === '0x') return 'registry'
+        // If decodeFrameCall returns something against the registry, it
+        // matched locally — show no pill.
+        const local = decodeFrameCall(this.contracts, this.frame.to || null, this.frame.input)
+        if (local) return 'registry'
+        const selector = this.frame.input.slice(0, 10).toLowerCase()
+        const extra = this.extraSignatures[selector]
+        return extra ? extra.source : 'registry'
+    }
+
+    private frameContractLabel(): string {
+        if (!this.frame.to) return ''
+        const c = findContractByAddress(this.contracts, this.frame.to)
+        if (c && c.name) return c.name
+        return this.shortAddr(this.frame.to)
+    }
+
+    get hasChildren(): boolean {
+        return !!(this.frame.calls && this.frame.calls.length)
+    }
+
+    get hasError(): boolean {
+        return !!(this.frame.error || this.frame.revertReason)
+    }
+
+    get typeClass(): string {
+        const t = (this.frame.type || '').toUpperCase()
+        if (t === 'DELEGATECALL') return 'is-delegate'
+        if (t === 'STATICCALL') return 'is-static'
+        if (t === 'CREATE' || t === 'CREATE2') return 'is-create'
+        if (t === 'SELFDESTRUCT') return 'is-destruct'
+        if (this.hasError) return 'is-error'
+        return 'is-call'
+    }
+
+    get gasLabel(): string {
+        if (!this.frame.gasUsed) return ''
+        const n = this.parseHex(this.frame.gasUsed)
+        if (!n) return ''
+        return n.toLocaleString()
+    }
+
+    get valueLabel(): string {
+        // VET amounts can be > 2^53, so JS number overflows into scientific
+        // notation. Format via BigNumber and convert wei → VET.
+        if (!this.frame.value) return ''
+        try {
+            const bn = BN(this.frame.value)
+            if (bn.isZero()) return ''
+            return bn.dividedBy(1e18).toFormat(4) + ' VET'
+        } catch {
+            return ''
+        }
+    }
+
+    get targetName(): string {
+        if (!this.frame.to) return ''
+        const c = findContractByAddress(this.contracts, this.frame.to)
+        return c ? (c.name || '') : ''
+    }
+
+    get rawSelector(): string {
+        if (!this.frame.input || this.frame.input.length < 10) return ''
+        return this.frame.input.slice(0, 10)
+    }
+
+    get inputsInline(): string {
+        if (!this.decoded) return ''
+        return this.decoded.inputs
+            .map((a) => `${a.name} = ${this.formatVal(a.value)}`)
+            .join(', ')
+    }
+
+    get returnInline(): string {
+        if (!this.decoded || !this.decoded.outputs || this.decoded.outputs.length === 0) return ''
+        if (this.decoded.outputs.length === 1) {
+            return this.formatVal(this.decoded.outputs[0].value)
+        }
+        return '(' + this.decoded.outputs.map((o) => this.formatVal(o.value)).join(', ') + ')'
+    }
+
+    get showInputDetail(): boolean {
+        // Show raw input only when we didn't decode it (otherwise inline args are enough).
+        return !this.decoded && !!this.frame.input && this.frame.input !== '0x'
+    }
+
+    get showOutputDetail(): boolean {
+        // Show raw output when there's data and we don't have a decoded form for it.
+        if (!this.frame.output || this.frame.output === '0x') return false
+        if (this.decoded && this.decoded.outputs && this.decoded.outputs.length) return false
+        return true
+    }
+
+    private shouldDefaultExpand(): boolean {
+        // Top two levels open by default; deeper frames collapsed to keep the
+        // initial view readable. Errored frames always start expanded so the
+        // user can see the failure path.
+        if (this.frame && (this.frame.error || this.frame.revertReason)) return true
+        return (this.depth ?? 0) < 2
+    }
+
+    private toggleExpanded() {
+        if (!this.hasChildren && !this.showInputDetail && !this.showOutputDetail && !this.frame.revertReason) return
+        this.expanded = !this.expanded
+    }
+
+    private parseHex(v: string): number {
+        if (!v) return 0
+        if (v.startsWith('0x')) return parseInt(v, 16)
+        return Number(v) || 0
+    }
+
+    private shortAddr(addr: string): string {
+        if (!addr) return ''
+        if (addr.length <= 12) return addr
+        return addr.slice(0, 8) + '…' + addr.slice(-4)
+    }
+
+    private formatVal(v: any): string {
+        if (v === null || v === undefined) return ''
+        if (typeof v === 'string') {
+            // Heuristic: looks like an address?
+            if (/^0x[0-9a-fA-F]{40}$/.test(v)) {
+                const c = findContractByAddress(this.contracts, v)
+                if (c && c.name) return c.name
+                return this.shortAddr(v)
+            }
+            // Long hex blobs get truncated.
+            if (/^0x[0-9a-fA-F]{12,}$/.test(v) && v.length > 18) {
+                return v.slice(0, 10) + '…' + v.slice(-4)
+            }
+            return v
+        }
+        if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+        if (typeof v === 'bigint') return v.toString()
+        if (Array.isArray(v)) {
+            const parts = v.slice(0, 4).map((x) => this.formatVal(x))
+            const more = v.length > 4 ? `, …+${v.length - 4}` : ''
+            return '[' + parts.join(', ') + more + ']'
+        }
+        if (v && typeof v.toString === 'function') return v.toString()
+        return JSON.stringify(v)
+    }
+
+    private async copyAddress(event?: MouseEvent) {
+        if (event) {
+            event.stopPropagation()
+            event.preventDefault()
+        }
+        if (!this.frame.to) return
+        try {
+            await navigator.clipboard.writeText(this.frame.to)
+            ;(this as any).$buefy.toast.open({
+                message: 'Address copied',
+                type: 'is-success',
+                position: 'is-bottom',
+                duration: 1500
+            })
+        } catch {
+            // Clipboard API unavailable (e.g. non-secure context) — fall back
+            // to the legacy execCommand trick so this still works.
+            try {
+                const ta = document.createElement('textarea')
+                ta.value = this.frame.to
+                ta.setAttribute('readonly', '')
+                ta.style.position = 'absolute'
+                ta.style.left = '-9999px'
+                document.body.appendChild(ta)
+                ta.select()
+                document.execCommand('copy')
+                document.body.removeChild(ta)
+                ;(this as any).$buefy.toast.open({
+                    message: 'Address copied',
+                    type: 'is-success',
+                    position: 'is-bottom',
+                    duration: 1500
+                })
+            } catch {
+                // give up silently
+            }
+        }
+    }
+
+    private truncated(s: string | undefined): string {
+        if (!s) return ''
+        if (s.length <= 130) return s
+        return s.slice(0, 66) + ' … ' + s.slice(-16) + ` (${(s.length - 2) / 2} bytes)`
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.trace-frame {
+    border-left: 2px solid transparent;
+    padding-left: 0.5rem;
+    margin-top: 0.2rem;
+}
+.trace-frame:first-child {
+    margin-top: 0;
+}
+.trace-frame.is-errored {
+    border-left-color: rgba(255, 56, 96, 0.45);
+}
+
+.frame-row {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.4rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.82rem;
+    line-height: 1.35;
+    flex-wrap: wrap;
+}
+.frame-row:hover {
+    background: var(--hover-bg);
+}
+
+.chevron {
+    background: transparent;
+    border: none;
+    color: var(--text-color-light);
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+.chevron.is-empty {
+    cursor: default;
+    visibility: hidden;
+}
+
+.type-chip {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.12rem 0.5rem;
+    border-radius: 3px;
+    background: var(--code-bg);
+    color: var(--text-color);
+    flex-shrink: 0;
+    min-width: 4.5rem;
+    text-align: center;
+}
+.type-chip.is-call     { background: rgba(50, 115, 220, 0.18); color: var(--primary-color); }
+.type-chip.is-static   { background: rgba(50, 175, 50, 0.18); color: #228822; }
+.type-chip.is-delegate { background: rgba(255, 165, 32, 0.18); color: #b88010; }
+.type-chip.is-create   { background: rgba(127, 86, 217, 0.22); color: #7f56d9; }
+.type-chip.is-destruct { background: rgba(216, 41, 77, 0.18); color: #d8294d; }
+.type-chip.is-error    { background: rgba(216, 41, 77, 0.18); color: #d8294d; }
+
+.gas-label {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    background: var(--code-bg);
+    padding: 0.08rem 0.4rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+    min-width: 3.5rem;
+    text-align: right;
+}
+
+.call-text {
+    font-family: monospace;
+    font-size: 0.82rem;
+    color: var(--text-color);
+    word-break: break-word;
+    flex: 1;
+    min-width: 0;
+}
+
+.contract-name {
+    color: var(--primary-color);
+    font-weight: 600;
+}
+.dot {
+    color: var(--text-color-light);
+}
+.fn-name {
+    color: var(--text-color);
+    font-weight: 600;
+}
+.fn-name.is-raw {
+    color: var(--text-color-light);
+}
+.args-inline {
+    color: var(--text-color-light);
+}
+.arrow {
+    color: var(--text-color-light);
+}
+.output-inline {
+    color: var(--text-color);
+}
+
+.value-label {
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    flex-shrink: 0;
+}
+
+.frame-addr {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    background: var(--code-bg);
+    padding: 0.18rem 0.5rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+    user-select: none;
+    position: relative;
+    z-index: 1;
+}
+.frame-row:hover .frame-addr {
+    opacity: 1;
+}
+.frame-addr .addr-text {
+    color: inherit;
+    font-size: inherit;
+    background: transparent;
+    padding: 0;
+}
+::v-deep .frame-addr .copy-icon {
+    font-size: 0.7rem;
+    opacity: 0.7;
+}
+.frame-addr:hover {
+    color: var(--primary-color);
+}
+.frame-addr:hover ::v-deep .copy-icon {
+    opacity: 1;
+}
+
+.error-tag {
+    font-size: 0.7rem;
+    color: #d8294d;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.45rem;
+    border-radius: 3px;
+    background: rgba(216, 41, 77, 0.12);
+    flex-shrink: 0;
+}
+
+
+.frame-extras {
+    margin: 0.25rem 0 0.25rem 2.6rem;
+    padding: 0.4rem 0.55rem;
+    background: var(--code-bg);
+    border-radius: 4px;
+    border: 1px dashed var(--border-color);
+}
+.extra-row {
+    display: flex;
+    gap: 0.6rem;
+    align-items: baseline;
+    font-size: 0.75rem;
+}
+.extra-row + .extra-row {
+    margin-top: 0.2rem;
+}
+.extra-row.is-revert {
+    color: #d8294d;
+}
+.extra-key {
+    color: var(--text-color-light);
+    text-transform: uppercase;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    flex-shrink: 0;
+    width: 50px;
+}
+.extra-val {
+    color: var(--text-color);
+    word-break: break-all;
+    flex: 1;
+    font-size: 0.78rem;
+}
+
+.frame-children {
+    margin-left: 0.85rem;
+    margin-top: 0.1rem;
+    border-left: 1px solid var(--border-color);
+    padding-left: 0.25rem;
+}
+</style>

--- a/src/components/Debugger/TxForensicsPanel.vue
+++ b/src/components/Debugger/TxForensicsPanel.vue
@@ -1,0 +1,1357 @@
+<template>
+    <div class="forensics">
+        <div v-if="loading" class="state-row">
+            <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+            <span>Fetching transaction…</span>
+        </div>
+
+        <div v-else-if="error" class="error-state">
+            <b-icon icon="exclamation-triangle" custom-class="has-text-warning"></b-icon>
+            <span>{{ error }}</span>
+        </div>
+
+        <template v-else-if="tx && receipt">
+            <!-- Header -->
+            <div class="card-block">
+                <div class="block-head">
+                    <div class="head-left">
+                        <span class="head-title">Transaction</span>
+                        <span
+                            class="status-pill"
+                            :class="receipt.reverted ? 'is-reverted' : 'is-success'"
+                        >
+                            <span class="status-dot"></span>
+                            {{ receipt.reverted ? 'Reverted' : 'Success' }}
+                        </span>
+                    </div>
+                    <a :href="$explorerTx + tx.id" target="_blank" rel="noopener" class="external-link">
+                        View on explorer
+                        <b-icon icon="external-link-alt" size="is-small"></b-icon>
+                    </a>
+                </div>
+
+                <div class="kv-grid">
+                    <div class="kv-row">
+                        <span class="kv-key">Tx ID</span>
+                        <code class="kv-val is-family-monospace">{{ tx.id }}</code>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Block</span>
+                        <span class="kv-val">
+                            #{{ tx.meta && tx.meta.blockNumber }}
+                            <span class="kv-aux">· {{ formatTimestamp(tx.meta && tx.meta.blockTimestamp) }}</span>
+                        </span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Origin</span>
+                        <code class="kv-val is-family-monospace">{{ tx.origin }}</code>
+                    </div>
+                    <div v-if="tx.delegator" class="kv-row">
+                        <span class="kv-key">Delegator</span>
+                        <code class="kv-val is-family-monospace">{{ tx.delegator }}</code>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Gas payer</span>
+                        <code class="kv-val is-family-monospace">{{ receipt.gasPayer }}</code>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Gas</span>
+                        <span class="kv-val">
+                            {{ receipt.gasUsed.toLocaleString() }} used
+                            <span class="kv-aux">/ {{ tx.gas.toLocaleString() }} limit</span>
+                        </span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Paid</span>
+                        <span class="kv-val">{{ formatVtho(receipt.paid) }} VTHO</span>
+                    </div>
+                    <div class="kv-row">
+                        <span class="kv-key">Clauses</span>
+                        <span class="kv-val">{{ tx.clauses.length }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Revert reason (only shown for failed txs; placed right after the header
+                 so the "why did this fail" answer is the first thing after the summary) -->
+            <div v-if="receipt.reverted" class="card-block">
+                <div class="block-head">
+                    <span class="head-title">Revert reason</span>
+                    <span v-if="revertClauseIndex !== null" class="head-aux">
+                        from clause #{{ revertClauseIndex }}
+                    </span>
+                </div>
+
+                <div v-if="revertLoading" class="state-row">
+                    <b-icon icon="circle-notch" custom-class="fa-spin"></b-icon>
+                    <span>Resolving revert reason…</span>
+                </div>
+
+                <div v-else-if="revertError" class="error-state inline">
+                    <b-icon icon="exclamation-triangle" custom-class="has-text-warning"></b-icon>
+                    <span>{{ revertError }}</span>
+                </div>
+
+                <template v-else-if="revert">
+                    <div v-if="revert.kind === 'string'" class="revert-block is-string">
+                        <span class="revert-label">Error(string)</span>
+                        <code class="revert-message">{{ revert.message }}</code>
+                    </div>
+
+                    <div v-else-if="revert.kind === 'panic'" class="revert-block is-panic">
+                        <span class="revert-label">Panic({{ revert.code }})</span>
+                        <code class="revert-message">{{ revert.description }}</code>
+                    </div>
+
+                    <div v-else-if="revert.kind === 'custom'" class="revert-block is-custom">
+                        <div class="revert-head">
+                            <span class="revert-label">Custom error</span>
+                            <code class="revert-name">{{ revert.canonicalName }}</code>
+                            <span class="revert-contract">defined in {{ revert.contract.name }}</span>
+                        </div>
+                        <ul v-if="revert.args.length" class="arg-list">
+                            <li v-for="(a, j) in revert.args" :key="j" class="arg-row">
+                                <span class="arg-type">{{ a.type }}</span>
+                                <span class="arg-name">{{ a.name }}</span>
+                                <code class="arg-value is-family-monospace">{{ formatArg(a.value) }}</code>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div v-else-if="revert.kind === 'vm-error'" class="revert-block is-vm-error">
+                        <div class="revert-head">
+                            <span class="revert-label">EVM halt</span>
+                            <code class="revert-name">{{ revert.error }}</code>
+                        </div>
+                        <p class="revert-aux">
+                            The EVM stopped execution without returning revert data — typically out-of-gas, invalid opcode, or stack/storage overflow inside a sub-call.
+                            <template v-if="revert.at && revert.at.to">
+                                Surfaced in a <code>{{ revert.at.type }}</code> to <code class="is-family-monospace">{{ revert.at.to }}</code>.
+                            </template>
+                            See the Internal trace card below for the full call path.
+                        </p>
+                    </div>
+
+                    <div v-else-if="revert.kind === 'empty'" class="revert-block is-raw">
+                        <span class="revert-label">No revert data</span>
+                        <span class="revert-aux">
+                            The tx reverted without returning data (likely <code>require()</code> with no message, or an <code>assert</code>).
+                        </span>
+                    </div>
+
+                    <div v-else-if="revert.kind === 'raw'" class="revert-block is-raw">
+                        <span class="revert-label">Unknown revert data</span>
+                        <span class="revert-aux">
+                            Selector didn't match Error/Panic or any imported custom error. Import the contract that defines this error to decode it.
+                        </span>
+                        <code class="revert-raw is-family-monospace">{{ revert.data }}</code>
+                    </div>
+
+                    <p v-if="revertSource === 'trace'" class="revert-source-note">
+                        <b-icon icon="check-circle" size="is-small" custom-class="source-icon-trace"></b-icon>
+                        Decoded from <code>/debug/tracers</code> — reflects the actual on-chain state at the failing block.
+                    </p>
+                    <p v-else-if="revertSource === 'simulation'" class="revert-caveat">
+                        Re-simulated at <code>blockNumber - 1</code> (tracer endpoint disabled on this node). Intra-block state effects from earlier transactions in the same block are not reproduced — the original revert may differ if your tx depended on them.
+                    </p>
+                </template>
+            </div>
+
+            <!-- Clauses -->
+            <div class="card-block">
+                <div class="block-head">
+                    <span class="head-title">Clauses</span>
+                </div>
+                <div
+                    v-for="(c, i) in tx.clauses"
+                    :key="i"
+                    class="clause-row"
+                    :class="{ 'is-reverted': isClauseReverted(i) }"
+                >
+                    <div class="clause-head">
+                        <span class="clause-index">#{{ i }}</span>
+                        <span class="clause-chip" :class="clauseChipClass(c)">{{ clauseChipLabel(c) }}</span>
+
+                        <span class="clause-call">
+                            <template v-if="c.to === null">
+                                <span class="contract-name">contract creation</span>
+                                <template v-if="receipt.outputs[i] && receipt.outputs[i].contractAddress">
+                                    <span class="dim-arrow">→</span>
+                                    <span class="contract-name">{{ shortAddr(receipt.outputs[i].contractAddress) }}</span>
+                                </template>
+                            </template>
+                            <template v-else-if="decodedCalls[i].decoded">
+                                <template v-if="!decodedCalls[i].fromB32">
+                                    <span class="contract-name">{{ decodedCalls[i].decoded.contract.name }}</span><span class="dim-dot">.</span><span class="fn-name">{{ decodedCalls[i].decoded.fnName }}</span>
+                                </template>
+                                <template v-else>
+                                    <span v-if="targetName(c.to)" class="contract-name">{{ targetName(c.to) }}</span><span v-else class="contract-name is-unknown">unknown</span><span class="dim-dot">.</span><span class="fn-name">{{ decodedCalls[i].decoded.fnName }}</span>
+                                </template>
+                            </template>
+                            <template v-else>
+                                <span class="contract-name" :class="{ 'is-unknown': !targetName(c.to) }">{{ targetName(c.to) || 'unknown' }}</span>
+                                <template v-if="rawSelectorFor(c.data)">
+                                    <span class="dim-dot">.</span>
+                                    <span class="fn-name is-raw">{{ rawSelectorFor(c.data) }}</span>
+                                </template>
+                            </template>
+                        </span>
+
+                        <span v-if="hasValue(c.value)" class="clause-value">
+                            {{ formatVet(c.value) }} VET
+                        </span>
+
+                        <span v-if="isClauseReverted(i)" class="reverted-tag">reverted</span>
+
+                        <span
+                            v-if="c.to"
+                            class="clause-addr"
+                            :title="c.to + ' — click to copy'"
+                            @click.stop.prevent="copyText(c.to, $event)"
+                            @mousedown.stop
+                            @mouseup.stop
+                        >
+                            <code class="is-family-monospace addr-text">{{ shortAddr(c.to) }}</code>
+                            <b-icon icon="copy" size="is-small" custom-class="copy-icon"></b-icon>
+                        </span>
+                    </div>
+
+                    <ul v-if="decodedCalls[i].decoded && decodedCalls[i].decoded.args.length" class="arg-list">
+                        <li v-for="(a, j) in decodedCalls[i].decoded.args" :key="j" class="arg-row">
+                            <span class="arg-type">{{ a.type }}</span>
+                            <span class="arg-name">{{ a.name }}</span>
+                            <code class="arg-value is-family-monospace">{{ formatArg(a.value) }}</code>
+                        </li>
+                    </ul>
+                    <div
+                        v-else-if="!decodedCalls[i].decoded && c.data && c.data !== '0x'"
+                        class="raw-call"
+                    >
+                        <div class="raw-label">Raw calldata (no matching ABI)</div>
+                        <code class="raw-data is-family-monospace">{{ c.data }}</code>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Events -->
+            <div class="card-block">
+                <div class="block-head">
+                    <span class="head-title">
+                        Events
+                        <span class="head-count">{{ totalEvents }}</span>
+                    </span>
+                </div>
+                <div v-if="totalEvents === 0" class="empty-mini">No events emitted.</div>
+                <template v-else>
+                    <div v-for="(group, gi) in eventGroups" :key="gi" class="event-row">
+                        <div class="event-head">
+                            <span class="event-clause-tag">clause #{{ group.clauseIndex }}</span>
+                            <template v-if="group.decoded">
+                                <code class="event-name">{{ group.decoded.eventName }}</code>
+                                <span class="event-contract">on {{ eventEmitterLabel(group) }}</span>
+                            </template>
+                            <template v-else>
+                                <span class="event-name-unknown">Unknown event</span>
+                                <code class="event-topic is-family-monospace">topic0 {{ group.raw.topics[0] }}</code>
+                            </template>
+                            <code class="event-address is-family-monospace">{{ group.raw.address }}</code>
+                        </div>
+                        <ul v-if="group.decoded" class="arg-list">
+                            <li v-for="(a, j) in group.decoded.args" :key="j" class="arg-row">
+                                <span v-if="a.indexed" class="indexed-badge">indexed</span>
+                                <span class="arg-type">{{ a.type }}</span>
+                                <span class="arg-name">{{ a.name }}</span>
+                                <code class="arg-value is-family-monospace">{{ formatArg(a.value) }}</code>
+                            </li>
+                        </ul>
+                        <div v-else class="raw-call">
+                            <div class="raw-label">topics</div>
+                            <code v-for="(t, j) in group.raw.topics" :key="j" class="raw-topic is-family-monospace">{{ t }}</code>
+                            <div class="raw-label">data</div>
+                            <code class="raw-data is-family-monospace">{{ group.raw.data || '0x' }}</code>
+                        </div>
+                    </div>
+                </template>
+            </div>
+
+            <InternalTraceSection
+                :tx="tx"
+                :receipt="receipt"
+                :contracts="contracts"
+                @contracts-updated="onTraceContractsUpdated"
+            />
+        </template>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator'
+import { Entities } from '../../database'
+import {
+    loadAllContracts,
+    ensureAbisForAddresses,
+    findContractByAddress,
+    decodeCalldata,
+    decodeCalldataWithAbiItem,
+    decodeLog,
+    decodeLogWithAbiItem,
+    decodeRevertData,
+    DecodedCall,
+    DecodedLog,
+    DecodedRevert
+} from '../../utils/abi-registry'
+import { fetchSignature } from '../../services/b32-service'
+import {
+    fetchSignatures as fetchOpenChainSignatures,
+    signatureToFunctionItem,
+    signatureToEventItem
+} from '../../services/openchain-service'
+import {
+    simulateClauses,
+    isTracerAvailable,
+    traceClauseCall,
+    getBlock
+} from '../../services/debug-service'
+import InternalTraceSection from './InternalTraceSection.vue'
+
+interface EventGroup {
+    clauseIndex: number
+    raw: Connex.VM.Event
+    decoded: DecodedLog | null
+    fromB32?: boolean
+}
+
+interface DecodedCallEntry {
+    decoded: DecodedCall | null
+    fromB32?: boolean
+}
+
+@Component({
+    name: 'TxForensicsPanel',
+    components: { InternalTraceSection }
+})
+export default class TxForensicsPanel extends Vue {
+    @Prop({ required: true })
+    private value!: string
+
+    private loading: boolean = false
+    private error: string = ''
+    private tx: Connex.Thor.Transaction | null = null
+    private receipt: Connex.Thor.Transaction.Receipt | null = null
+    private contracts: Entities.Contract[] = []
+    private revert: DecodedRevert | null = null
+    private revertClauseIndex: number | null = null
+    private revertLoading: boolean = false
+    private revertError: string = ''
+    private revertSource: 'trace' | 'simulation' | null = null
+    // Lazy-fetched b32 keccak DB lookups for events/functions our local
+    // registry can't decode. Keyed by lowercase hex hash.
+    private b32EventSigs: Record<string, any> = {}
+    private b32FunctionSigs: Record<string, any> = {}
+
+    get decodedCalls(): DecodedCallEntry[] {
+        if (!this.tx) return []
+        return this.tx.clauses.map((c) => {
+            const local = decodeCalldata(this.contracts, c.to, c.data)
+            if (local) return { decoded: local }
+            if (c.data && c.data.length >= 10) {
+                const selector = c.data.slice(0, 10).toLowerCase()
+                const item = this.b32FunctionSigs[selector]
+                if (item) {
+                    const fromB32 = decodeCalldataWithAbiItem(c.data, item)
+                    if (fromB32) return { decoded: fromB32, fromB32: true }
+                }
+            }
+            return { decoded: null }
+        })
+    }
+
+    get eventGroups(): EventGroup[] {
+        if (!this.receipt) return []
+        const groups: EventGroup[] = []
+        this.receipt.outputs.forEach((out, idx) => {
+            (out.events || []).forEach((ev) => {
+                let decoded = decodeLog(this.contracts, ev)
+                let fromB32 = false
+                if (!decoded && ev.topics && ev.topics[0]) {
+                    const item = this.b32EventSigs[ev.topics[0].toLowerCase()]
+                    if (item) {
+                        const b32Decoded = decodeLogWithAbiItem(ev, item)
+                        if (b32Decoded) {
+                            decoded = b32Decoded
+                            fromB32 = true
+                        }
+                    }
+                }
+                groups.push({ clauseIndex: idx, raw: ev, decoded, fromB32 })
+            })
+        })
+        return groups
+    }
+
+    get totalEvents(): number {
+        return this.eventGroups.length
+    }
+
+    private isClauseReverted(i: number): boolean {
+        if (!this.receipt || !this.receipt.reverted) return false
+        // Thor reverts the whole tx; mark only the last executed clause to avoid noise.
+        return i === this.receipt.outputs.length - 1
+    }
+
+    private targetName(addr: string): string {
+        const c = findContractByAddress(this.contracts, addr)
+        return c ? (c.name || '') : ''
+    }
+
+    private shortAddr(addr: string | null | undefined): string {
+        if (!addr) return ''
+        if (addr.length <= 12) return addr
+        return addr.slice(0, 8) + '…' + addr.slice(-4)
+    }
+
+    // For events decoded via b32 we don't know the parent contract name. Try
+    // to fall back to a registry lookup on the emitter address, otherwise
+    // surface the short address.
+    private eventEmitterLabel(group: EventGroup): string {
+        if (!group.decoded) return ''
+        if (!group.fromB32) return group.decoded.contract.name
+        const name = this.targetName(group.raw.address)
+        if (name) return name
+        return this.shortAddr(group.raw.address)
+    }
+
+    private rawSelectorFor(data: string | undefined): string {
+        if (!data || data.length < 10) return ''
+        return data.slice(0, 10)
+    }
+
+    private clauseChipLabel(c: { to: string | null; value: string; data: string }): string {
+        if (c.to === null) return 'CREATE'
+        if (!c.data || c.data === '0x') return 'TRANSFER'
+        return 'CALL'
+    }
+
+    private clauseChipClass(c: { to: string | null; value: string; data: string }): string {
+        if (c.to === null) return 'is-create'
+        if (!c.data || c.data === '0x') return 'is-transfer'
+        return 'is-call'
+    }
+
+    private async copyText(text: string, event?: MouseEvent) {
+        if (event) {
+            event.stopPropagation()
+            event.preventDefault()
+        }
+        if (!text) return
+        try {
+            await navigator.clipboard.writeText(text)
+        } catch {
+            try {
+                const ta = document.createElement('textarea')
+                ta.value = text
+                ta.setAttribute('readonly', '')
+                ta.style.position = 'absolute'
+                ta.style.left = '-9999px'
+                document.body.appendChild(ta)
+                ta.select()
+                document.execCommand('copy')
+                document.body.removeChild(ta)
+            } catch { return }
+        }
+        ;(this as any).$buefy.toast.open({
+            message: 'Address copied',
+            type: 'is-success',
+            position: 'is-bottom',
+            duration: 1500
+        })
+    }
+
+    private hasValue(v: string): boolean {
+        if (!v) return false
+        const n = v.startsWith('0x') ? parseInt(v, 16) : Number(v)
+        return n > 0
+    }
+
+    private formatVet(wei: string): string {
+        try {
+            const bn = BN(wei || '0')
+            return bn.dividedBy(1e18).toFormat()
+        } catch {
+            return wei
+        }
+    }
+
+    private formatVtho(wei: string): string {
+        return this.formatVet(wei)
+    }
+
+    private formatTimestamp(ts: number | undefined): string {
+        if (!ts) return ''
+        const d = new Date(ts * 1000)
+        return d.toLocaleString()
+    }
+
+    private formatArg(v: any): string {
+        if (v === null || v === undefined) return ''
+        if (typeof v === 'string') return v
+        if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+        if (typeof v === 'bigint') return v.toString()
+        if (Array.isArray(v)) return '[' + v.map((x) => this.formatArg(x)).join(', ') + ']'
+        if (v && typeof v.toString === 'function') return v.toString()
+        return JSON.stringify(v)
+    }
+
+    private async load() {
+        this.loading = true
+        this.error = ''
+        this.tx = null
+        this.receipt = null
+        this.revert = null
+        this.revertClauseIndex = null
+        this.revertError = ''
+        try {
+            const [tx, receipt, contracts] = await Promise.all([
+                this.$connex.thor.transaction(this.value).get(),
+                this.$connex.thor.transaction(this.value).getReceipt(),
+                loadAllContracts(this.$connex.thor.genesis.id)
+            ])
+            this.contracts = contracts
+            if (!tx) {
+                this.error = 'Transaction not found on the current network.'
+                return
+            }
+            this.tx = tx
+            if (!receipt) {
+                this.error = 'Transaction found but no receipt yet (still pending?).'
+                return
+            }
+            this.receipt = receipt
+
+            // Try filling registry gaps from Sourcify for every address
+            // touched by this tx (clause targets + event emitters). This is
+            // best-effort and silent.
+            const addresses: Array<string | null | undefined> = []
+            tx.clauses.forEach((c) => addresses.push(c.to))
+            receipt.outputs.forEach((out) => {
+                ;(out.events || []).forEach((ev) => addresses.push(ev.address))
+                if (out.contractAddress) addresses.push(out.contractAddress)
+            })
+            ensureAbisForAddresses(this.$connex.thor.genesis.id, addresses, this.$nodeUrl)
+                .then((refreshed) => {
+                    this.contracts = refreshed
+                    // Sourcify may have backfilled some ABIs — run b32 only for
+                    // the leftovers afterwards.
+                    this.enrichFromB32()
+                })
+                .catch(() => {
+                    // Sourcify failed; still try b32.
+                    this.enrichFromB32()
+                })
+
+            if (receipt.reverted) {
+                this.resolveRevertReason()
+            }
+        } catch (e: any) {
+            this.error = e && e.message ? e.message : 'Failed to load transaction.'
+        } finally {
+            this.loading = false
+        }
+    }
+
+    // When the internal trace finishes loading it Sourcify-enriches every
+    // address it found in the call tree (impls inside delegatecall chains,
+    // helper contracts, etc.) and emits the refreshed contracts list. We
+    // merge it in and re-run b32 enrichment in case the new ABIs cover
+    // previously-unknown event topics or selectors.
+    private async onTraceContractsUpdated(refreshed: Entities.Contract[]) {
+        this.contracts = refreshed
+        await this.enrichFromB32()
+    }
+
+    // For every event topic0 + clause selector that our local registry can't
+    // decode, query b32 first, then OpenChain. Results land in reactive maps
+    // and the eventGroups / decodedCalls getters pick them up automatically.
+    // The b32* maps hold ABI items keyed by hash regardless of source.
+    private async enrichFromB32() {
+        if (!this.tx || !this.receipt) return
+
+        const unknownTopics = new Map<string, Connex.VM.Event>()
+        this.receipt.outputs.forEach((out) => {
+            (out.events || []).forEach((ev) => {
+                if (!ev.topics || !ev.topics[0]) return
+                if (decodeLog(this.contracts, ev)) return
+                unknownTopics.set(ev.topics[0].toLowerCase(), ev)
+            })
+        })
+
+        const unknownSelectors = new Set<string>()
+        this.tx.clauses.forEach((c) => {
+            if (!c.data || c.data.length < 10) return
+            if (decodeCalldata(this.contracts, c.to, c.data)) return
+            unknownSelectors.add(c.data.slice(0, 10).toLowerCase())
+        })
+
+        // Step 1: b32 keccak DB (returns full ABI items including indexed
+        // flags for events). Local cache means second-look is instant.
+        const stillUnknownTopics = new Map(unknownTopics)
+        const stillUnknownSelectors = new Set(unknownSelectors)
+        const b32FnPending: Record<string, any> = {}
+        const b32EvPending: Record<string, any> = {}
+
+        await Promise.all(
+            [...unknownTopics.keys(), ...unknownSelectors].map(async (hash) => {
+                const sig = await fetchSignature(hash)
+                if (!sig || !sig.item) return
+                const item = sig.item
+                if (item.type === 'event' && unknownTopics.has(hash)) {
+                    b32EvPending[hash] = item
+                    stillUnknownTopics.delete(hash)
+                } else if (item.type === 'function' && unknownSelectors.has(hash)) {
+                    b32FnPending[hash] = item
+                    stillUnknownSelectors.delete(hash)
+                }
+            })
+        )
+
+        // Step 2: OpenChain batched lookups for the leftovers — one HTTP
+        // request per kind instead of N. Function decode works from canonical
+        // signature alone. Events need a best-guess at which params are
+        // indexed, which we derive from each live log's topic count.
+        const [ocFnMap, ocEvMap] = await Promise.all([
+            stillUnknownSelectors.size > 0
+                ? fetchOpenChainSignatures('function', Array.from(stillUnknownSelectors))
+                : Promise.resolve(new Map()),
+            stillUnknownTopics.size > 0
+                ? fetchOpenChainSignatures('event', Array.from(stillUnknownTopics.keys()))
+                : Promise.resolve(new Map())
+        ])
+
+        const ocFnPending: Record<string, any> = {}
+        const ocEvPending: Record<string, any> = {}
+
+        for (const [hash, sig] of ocFnMap.entries()) {
+            if (!sig.canonicalSignature) continue
+            const item = signatureToFunctionItem(sig.canonicalSignature)
+            if (item) ocFnPending[hash] = item
+        }
+
+        for (const [hash, sig] of ocEvMap.entries()) {
+            if (!sig.canonicalSignature) continue
+            const ev = stillUnknownTopics.get(hash)
+            if (!ev) continue
+            const numIndexed = Math.max(0, (ev.topics || []).length - 1)
+            let item = signatureToEventItem(sig.canonicalSignature, numIndexed, false)
+            if (item && !decodeLogWithAbiItem(ev, item)) {
+                item = signatureToEventItem(sig.canonicalSignature, numIndexed, true)
+                if (item && !decodeLogWithAbiItem(ev, item)) item = null
+            }
+            if (item) ocEvPending[hash] = item
+        }
+
+        // Single reactive commit per map — all decoded rows update together.
+        const mergedFn = { ...this.b32FunctionSigs, ...b32FnPending, ...ocFnPending }
+        const mergedEv = { ...this.b32EventSigs, ...b32EvPending, ...ocEvPending }
+        if (Object.keys(mergedFn).length !== Object.keys(this.b32FunctionSigs).length) {
+            this.b32FunctionSigs = mergedFn
+        }
+        if (Object.keys(mergedEv).length !== Object.keys(this.b32EventSigs).length) {
+            this.b32EventSigs = mergedEv
+        }
+    }
+
+    private async resolveRevertReason() {
+        if (!this.tx || !this.receipt) return
+        this.revertLoading = true
+        this.revertError = ''
+        this.revertSource = null
+        try {
+            // 1) Prefer the call tracer — it runs against the real on-chain
+            // state at the failing block, so it sidesteps the intra-block
+            // dependency problem that hits re-simulation.
+            const traced = await this.tryResolveViaTracer()
+            if (traced) {
+                this.revert = traced
+                this.revertSource = 'trace'
+                return
+            }
+
+            // 2) Fall back to re-simulation at blockNumber - 1. Less accurate
+            // when the failing tx depended on state changes from earlier txs
+            // in the same block, but works on every node.
+            const blockNumber = this.tx.meta.blockNumber
+            const revision = blockNumber > 0 ? blockNumber - 1 : 0
+            const outputs = await simulateClauses(
+                this.$nodeUrl,
+                this.tx.clauses.map((c) => ({ to: c.to, value: c.value, data: c.data })),
+                {
+                    caller: this.tx.origin,
+                    gas: this.tx.gas,
+                    gasPayer: this.receipt.gasPayer
+                },
+                revision
+            )
+
+            const idx = outputs.findIndex((o) => o.reverted)
+            if (idx === -1) {
+                this.revertError =
+                    'Simulation succeeded — could not reproduce the on-chain revert (possibly an intra-block state dependency). The node\'s tracer endpoint is disabled, so we can\'t replay the actual on-chain execution either.'
+                return
+            }
+            this.revertClauseIndex = idx
+            const target = this.tx.clauses[idx] ? this.tx.clauses[idx].to : null
+
+            const refreshed = await ensureAbisForAddresses(
+                this.$connex.thor.genesis.id,
+                [target],
+                this.$nodeUrl
+            )
+            this.contracts = refreshed
+            this.revert = decodeRevertData(refreshed, target, outputs[idx].data)
+            this.revertSource = 'simulation'
+        } catch (e: any) {
+            this.revertError = e && e.message ? e.message : 'Failed to determine the revert reason.'
+        } finally {
+            this.revertLoading = false
+        }
+    }
+
+    private async tryResolveViaTracer(): Promise<DecodedRevert | null> {
+        if (!this.tx || !this.receipt) return null
+
+        // A 400 from /debug/tracers with a bogus target means "endpoint up,
+        // bad input" — which is what isTracerAvailable looks for.
+        const probeTarget = `${this.receipt.meta.blockID}/0/0`
+        const available = await isTracerAvailable(this.$nodeUrl, probeTarget)
+        if (!available) return null
+
+        const block = await getBlock(this.$nodeUrl, this.receipt.meta.blockID).catch(() => null)
+        if (!block) return null
+        const txIndex = block.transactions.findIndex(
+            (id) => id.toLowerCase() === this.tx!.id.toLowerCase()
+        )
+        if (txIndex === -1) return null
+
+        // Walk the clauses and find the one that the tracer reports as
+        // reverted. We stop at the first reverted clause — that's the failing
+        // one (the receipt's reverted flag is set on the whole tx).
+        for (let i = 0; i < this.tx.clauses.length; i++) {
+            let frame
+            try {
+                frame = await traceClauseCall(
+                    this.$nodeUrl,
+                    this.receipt.meta.blockID,
+                    txIndex,
+                    i
+                )
+            } catch {
+                continue
+            }
+            if (!frame) continue
+            if (!frame.error && !frame.revertReason && !this.frameTreeHasError(frame)) continue
+
+            this.revertClauseIndex = i
+            const target = this.tx.clauses[i] ? this.tx.clauses[i].to : null
+
+            const refreshed = await ensureAbisForAddresses(
+                this.$connex.thor.genesis.id,
+                [target],
+                this.$nodeUrl
+            )
+            this.contracts = refreshed
+
+            // The outermost frame's `output` is usually the propagated revert
+            // data — but only when the failure was a Solidity revert. EVM-level
+            // halts (out-of-gas, invalid opcode, etc.) leave the outer output
+            // empty and only show as `error` on the deepest reverting frame.
+            // So: if top-level output decodes to something useful, use it;
+            // otherwise drill down to the deepest erroring frame.
+            if (frame.output && frame.output !== '0x') {
+                const decoded = decodeRevertData(refreshed, target, frame.output)
+                if (decoded.kind !== 'raw' && decoded.kind !== 'empty') {
+                    return decoded
+                }
+            }
+
+            const deepest = this.findDeepestErrorFrame(frame)
+            if (deepest && deepest !== frame) {
+                if (deepest.output && deepest.output !== '0x') {
+                    const innerTarget = deepest.to || target
+                    return decodeRevertData(refreshed, innerTarget, deepest.output)
+                }
+                if (deepest.revertReason) {
+                    return { kind: 'string', message: deepest.revertReason }
+                }
+                if (deepest.error) {
+                    return {
+                        kind: 'vm-error',
+                        error: deepest.error,
+                        at: { type: deepest.type, to: deepest.to }
+                    }
+                }
+            }
+
+            if (frame.revertReason) {
+                return { kind: 'string', message: frame.revertReason }
+            }
+            if (frame.error) {
+                return {
+                    kind: 'vm-error',
+                    error: frame.error,
+                    at: { type: frame.type, to: frame.to }
+                }
+            }
+            return { kind: 'empty' }
+        }
+        return null
+    }
+
+    private frameTreeHasError(frame: any): boolean {
+        if (frame.error || frame.revertReason) return true
+        if (frame.calls && frame.calls.length) {
+            return frame.calls.some((c: any) => this.frameTreeHasError(c))
+        }
+        return false
+    }
+
+    // Returns the deepest frame in the call tree that has an `error` or
+    // non-empty `output`. Deepest = the originating cause for nested
+    // failures like an inner DELEGATECALL that ran out of gas.
+    private findDeepestErrorFrame(frame: any): any | null {
+        let deepest: any | null = null
+        const walk = (f: any) => {
+            const hasInfo =
+                !!f.error ||
+                !!f.revertReason ||
+                (typeof f.output === 'string' && f.output !== '0x')
+            if (hasInfo) {
+                deepest = f
+            }
+            if (f.calls && f.calls.length) {
+                for (const child of f.calls) walk(child)
+            }
+        }
+        walk(frame)
+        return deepest
+    }
+
+    @Watch('value', { immediate: true })
+    private onValueChange() {
+        this.load()
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.forensics {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.state-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-color-light);
+    padding: 1.5rem;
+    justify-content: center;
+}
+
+.error-state {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 165, 32, 0.1);
+    border: 1px solid rgba(255, 165, 32, 0.3);
+    border-radius: 6px;
+    color: var(--text-color);
+    font-size: 0.9rem;
+}
+
+.card-block {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+}
+
+.block-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid var(--border-color);
+}
+.head-left {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+.head-title {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 700;
+    color: var(--text-color);
+}
+.head-count {
+    margin-left: 0.4rem;
+    font-size: 0.7rem;
+    background: var(--code-bg);
+    padding: 0.1rem 0.45rem;
+    border-radius: 10px;
+    color: var(--text-color-light);
+    font-weight: 600;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.status-pill.is-success {
+    background: rgba(50, 175, 50, 0.12);
+    color: #228822;
+}
+.status-pill.is-reverted {
+    background: rgba(255, 56, 96, 0.12);
+    color: #d8294d;
+}
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.external-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--primary-color);
+    text-decoration: none;
+    font-size: 0.8rem;
+}
+.external-link:hover {
+    text-decoration: underline;
+}
+
+.kv-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem 1.5rem;
+}
+.kv-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    font-size: 0.85rem;
+    min-width: 0;
+}
+.kv-key {
+    color: var(--text-color-light);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    flex-shrink: 0;
+    width: 95px;
+}
+.kv-val {
+    color: var(--text-color);
+    word-break: break-all;
+    min-width: 0;
+}
+.kv-aux {
+    color: var(--text-color-light);
+    font-size: 0.78rem;
+}
+
+.clause-row {
+    padding: 0.7rem 0.9rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--code-bg);
+    margin-bottom: 0.6rem;
+    transition: border-color 0.15s ease;
+}
+.clause-row.is-reverted {
+    border-color: rgba(255, 56, 96, 0.4);
+    background: rgba(255, 56, 96, 0.06);
+}
+.clause-row:last-child {
+    margin-bottom: 0;
+}
+.clause-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    font-size: 0.88rem;
+    line-height: 1.35;
+}
+.clause-index {
+    font-weight: 700;
+    color: var(--text-color-light);
+    font-family: monospace;
+    font-size: 0.82rem;
+}
+.clause-chip {
+    font-size: 0.62rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.12rem 0.5rem;
+    border-radius: 3px;
+    background: var(--code-bg);
+    flex-shrink: 0;
+    min-width: 4.5rem;
+    text-align: center;
+}
+.clause-chip.is-call     { background: rgba(50, 115, 220, 0.18); color: var(--primary-color); }
+.clause-chip.is-transfer { background: rgba(50, 175, 50, 0.18); color: #228822; }
+.clause-chip.is-create   { background: rgba(127, 86, 217, 0.22); color: #7f56d9; }
+
+.clause-call {
+    font-family: monospace;
+    font-size: 0.88rem;
+    color: var(--text-color);
+    word-break: break-word;
+    flex: 1;
+    min-width: 0;
+}
+.clause-call .contract-name {
+    color: var(--primary-color);
+    font-weight: 600;
+}
+.clause-call .contract-name.is-unknown {
+    color: var(--text-color-light);
+    font-style: italic;
+    font-weight: 500;
+}
+.clause-call .fn-name {
+    color: var(--text-color);
+    font-weight: 600;
+}
+.clause-call .fn-name.is-raw {
+    color: var(--text-color-light);
+    font-weight: 500;
+}
+.clause-call .dim-dot,
+.clause-call .dim-arrow {
+    color: var(--text-color-light);
+    margin: 0 0.1rem;
+}
+
+.clause-value {
+    font-weight: 600;
+    color: var(--text-color);
+    font-size: 0.82rem;
+    flex-shrink: 0;
+}
+
+.reverted-tag {
+    font-size: 0.65rem;
+    color: #d8294d;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.45rem;
+    border-radius: 3px;
+    background: rgba(216, 41, 77, 0.12);
+    flex-shrink: 0;
+}
+
+
+.clause-addr {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    background: var(--card-background);
+    padding: 0.18rem 0.5rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+    user-select: none;
+    position: relative;
+    z-index: 1;
+}
+.clause-row:hover .clause-addr {
+    opacity: 1;
+}
+.clause-addr .addr-text {
+    color: inherit;
+    font-size: inherit;
+    background: transparent;
+    padding: 0;
+}
+::v-deep .clause-addr .copy-icon {
+    font-size: 0.7rem;
+    opacity: 0.7;
+}
+.clause-addr:hover {
+    color: var(--primary-color);
+}
+.clause-addr:hover ::v-deep .copy-icon {
+    opacity: 1;
+}
+
+.arg-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.clause-row > .arg-list {
+    margin: 0.5rem 0 0 5.5rem;
+    border-left: 1px solid var(--border-color);
+    padding-left: 0.75rem;
+}
+.clause-row > .raw-call {
+    margin: 0.5rem 0 0 5.5rem;
+}
+.arg-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.3rem 0;
+    font-size: 0.82rem;
+    border-bottom: 1px dashed var(--border-color);
+    flex-wrap: wrap;
+}
+.arg-row:last-child {
+    border-bottom: none;
+}
+.arg-type {
+    color: var(--text-color);
+    font-weight: 600;
+    font-family: monospace;
+    font-size: 0.78rem;
+}
+.arg-name {
+    color: var(--text-color-light);
+    font-family: monospace;
+    font-size: 0.78rem;
+}
+.arg-value {
+    color: var(--text-color);
+    word-break: break-all;
+    font-size: 0.8rem;
+    flex: 1;
+}
+.arg-list-empty {
+    font-size: 0.8rem;
+    color: var(--text-color-light);
+    font-style: italic;
+}
+
+.raw-call {
+    background: var(--card-background);
+    padding: 0.5rem 0.6rem;
+    border-radius: 4px;
+    border: 1px dashed var(--border-color);
+}
+.raw-label {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-color-light);
+    margin: 0.2rem 0;
+}
+.raw-data,
+.raw-topic {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-color);
+    word-break: break-all;
+    margin-bottom: 0.2rem;
+}
+
+.event-row {
+    padding: 0.7rem 0.85rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--code-bg);
+    margin-bottom: 0.5rem;
+}
+.event-row:last-child {
+    margin-bottom: 0;
+}
+.event-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.4rem;
+    font-size: 0.85rem;
+}
+.event-clause-tag {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    padding: 0.1rem 0.45rem;
+    border-radius: 10px;
+    font-size: 0.7rem;
+    color: var(--text-color-light);
+    font-weight: 600;
+}
+.event-name {
+    font-weight: 700;
+    color: var(--text-color);
+}
+.event-name-unknown {
+    font-style: italic;
+    color: var(--text-color-light);
+}
+.event-contract {
+    color: var(--text-color-light);
+    font-size: 0.8rem;
+}
+.event-address {
+    margin-left: auto;
+    color: var(--text-color-light);
+    font-size: 0.78rem;
+}
+.event-topic {
+    color: var(--text-color-light);
+    font-size: 0.75rem;
+}
+.indexed-badge {
+    background: rgba(50, 115, 220, 0.12);
+    color: var(--primary-color);
+    font-size: 0.62rem;
+    font-weight: 600;
+    padding: 0.05rem 0.35rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.empty-mini {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+    padding: 0.4rem 0;
+}
+
+.soon-block .soon-text {
+    color: var(--text-color-light);
+    font-size: 0.85rem;
+}
+
+.head-aux {
+    font-size: 0.72rem;
+    color: var(--text-color-light);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.error-state.inline {
+    margin: 0;
+}
+
+.revert-block {
+    padding: 0.75rem 0.85rem;
+    border-radius: 6px;
+    border: 1px solid var(--border-color);
+    background: var(--code-bg);
+}
+.revert-block.is-string,
+.revert-block.is-panic,
+.revert-block.is-custom,
+.revert-block.is-vm-error {
+    border-color: rgba(255, 56, 96, 0.35);
+    background: rgba(255, 56, 96, 0.05);
+}
+
+.revert-label {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #d8294d;
+    margin-right: 0.6rem;
+}
+
+.revert-message {
+    font-size: 0.95rem;
+    color: var(--text-color);
+    word-break: break-word;
+}
+
+.revert-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+}
+.revert-name {
+    font-weight: 700;
+    color: var(--text-color);
+    font-size: 0.9rem;
+}
+.revert-contract {
+    color: var(--text-color-light);
+    font-size: 0.8rem;
+}
+
+.revert-aux {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+}
+.revert-raw {
+    display: block;
+    margin-top: 0.5rem;
+    word-break: break-all;
+    font-size: 0.78rem;
+    color: var(--text-color);
+}
+.revert-caveat {
+    margin-top: 0.6rem;
+    font-size: 0.75rem;
+    color: var(--text-color-light);
+}
+.revert-caveat code {
+    font-size: 0.72rem;
+}
+.revert-source-note {
+    margin-top: 0.6rem;
+    font-size: 0.75rem;
+    color: var(--text-color-light);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.revert-source-note code {
+    font-size: 0.72rem;
+}
+::v-deep .source-icon-trace {
+    color: #228822;
+}
+
+::v-deep .fa-spin {
+    animation: fa-spin 1.2s linear infinite;
+}
+@keyframes fa-spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (max-width: 768px) {
+    .kv-grid {
+        grid-template-columns: 1fr;
+    }
+}
+</style>

--- a/src/components/Debugger/lookup-panel.scss
+++ b/src/components/Debugger/lookup-panel.scss
@@ -1,0 +1,160 @@
+.lookup-panel {
+    margin: 1rem;
+    padding: 1.25rem;
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+}
+
+.lookup-header {
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.header-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-light);
+    margin-bottom: 0.3rem;
+}
+
+.header-value {
+    font-size: 0.85rem;
+    color: var(--text-color);
+    word-break: break-all;
+    padding: 0.4rem 0.6rem;
+    background: var(--code-bg);
+    border-radius: 4px;
+}
+
+.state-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-color-light);
+    font-size: 0.9rem;
+    padding: 0.5rem 0;
+}
+
+.empty {
+    text-align: center;
+    padding: 1.5rem 0.5rem;
+}
+.empty-title {
+    font-weight: 600;
+    color: var(--text-color);
+    margin: 0.5rem 0 0.25rem;
+}
+.empty-desc {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+    margin: 0;
+}
+
+.results > * + * {
+    margin-top: 1rem;
+}
+
+.canonical-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+.canonical-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-light);
+}
+.canonical-name {
+    font-family: monospace;
+    font-size: 0.95rem;
+    color: var(--text-color);
+    background: var(--code-bg);
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    word-break: break-all;
+}
+
+.inputs-label,
+.contracts-label,
+.meta-key {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-light);
+    margin-bottom: 0.4rem;
+}
+
+.inputs-list,
+.contracts-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.inputs-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.3rem 0;
+    font-family: monospace;
+    font-size: 0.85rem;
+    border-bottom: 1px dashed var(--border-color);
+}
+.inputs-list li:last-child {
+    border-bottom: none;
+}
+.indexed-badge {
+    background: rgba(50, 115, 220, 0.12);
+    color: var(--primary-color);
+    font-size: 0.65rem;
+    font-weight: 600;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.arg-type {
+    color: var(--text-color);
+    font-weight: 600;
+}
+.arg-name {
+    color: var(--text-color-light);
+}
+
+.meta-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+.meta-val {
+    font-size: 0.85rem;
+    color: var(--text-color);
+    font-weight: 500;
+}
+
+.contract-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 4px;
+    background: var(--code-bg);
+    margin-bottom: 0.35rem;
+}
+.contract-name {
+    font-weight: 600;
+    color: var(--text-color);
+    font-size: 0.9rem;
+}
+.contract-address {
+    font-size: 0.8rem;
+    color: var(--text-color-light);
+    word-break: break-all;
+}

--- a/src/components/Debugger/panel-stub.scss
+++ b/src/components/Debugger/panel-stub.scss
@@ -1,0 +1,32 @@
+.panel-stub {
+    padding: 1.5rem;
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    margin: 1rem;
+}
+
+.stub-kind {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-color-light);
+    margin-bottom: 0.5rem;
+}
+
+.stub-value {
+    font-size: 0.9rem;
+    color: var(--text-color);
+    word-break: break-all;
+    padding: 0.5rem 0.75rem;
+    background: var(--code-bg);
+    border-radius: 4px;
+    margin-bottom: 0.75rem;
+}
+
+.stub-hint {
+    font-size: 0.85rem;
+    color: var(--text-color-light);
+    margin: 0;
+}

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -56,9 +56,6 @@
                     active-class="has-background-grey-dark"
                     :to="{name: 'short_cuts'}"
                 >Shortcuts</router-link>
-                <a class="navbar-item" href="https://github.com/vechain/inspector-app" target="_blank">
-                    GitHub
-                </a>
             </div>
             <div class="navbar-end">
                 <div class="navbar-item">
@@ -126,6 +123,7 @@ export default class Navbar extends Vue {
     private routes = [
         { name: 'contracts', text: 'Contracts' },
         { name: 'tx_builder', text: 'TX Builder' },
+        { name: 'debugger', text: 'Debugger' },
         { name: 'deploy', text: 'Deploy' }
     ]
 

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -194,7 +194,11 @@ export default class Navbar extends Vue {
             return
         }
         localStorage.setItem('last-net', type)
-        window.location.href = window.location.origin
+        // Reload in place so the current route + hash survive — main.ts will
+        // pick up the new `last-net` and rebuild Connex against the right node.
+        // Previously this redirected to the origin (which dropped the path),
+        // forcing users back to /contracts every time they switched networks.
+        window.location.reload()
     }
 
     private openAddNetworkModal() {

--- a/src/custom.scss
+++ b/src/custom.scss
@@ -80,7 +80,12 @@ $link-focus-border: $primary;
   // Sidebar
   --sidebar-background: #ffffff;
   --sidebar-border: #dbdbdb;
-  
+
+  // Inline code / monospace surfaces
+  --code-bg: #f5f5f5;
+  --code-color: #4a4a4a;
+  --hover-bg: #f0f0f0;
+
   // Animations
   --anim-highlight-bg-from: rgba(0, 209, 178, 0.8);
   --anim-highlight-text-from: #fff;
@@ -139,7 +144,12 @@ $link-focus-border: $primary;
   // Sidebar
   --sidebar-background: #1f1f1f;
   --sidebar-border: #404040;
-  
+
+  // Inline code / monospace surfaces
+  --code-bg: #1c1c1c;
+  --code-color: #e0e0e0;
+  --hover-bg: #2e2e2e;
+
   // Animations
   --anim-highlight-bg-from: rgba(0, 209, 178, 0.6);
   --anim-highlight-text-from: #fff;
@@ -152,6 +162,12 @@ $link-focus-border: $primary;
 body {
   background-color: var(--body-background);
   color: var(--text-color);
+}
+
+// Theme-aware inline code surfaces (overrides Bulma's hardcoded light-mode values).
+code {
+  background-color: var(--code-bg);
+  color: var(--code-color);
 }
 
 // Custom scrollbar styling

--- a/src/database.ts
+++ b/src/database.ts
@@ -61,6 +61,40 @@ export namespace Entities {
     createdTime: number;
     updatedTime: number;
   }
+
+  export interface SourcedAbi {
+    id?: number;
+    genesisId: string;
+    address: string; // lowercase; the address users see (proxy if applicable)
+    abi: any[];
+    source: string; // 'sourcify' for now
+    fetchedTime: number;
+    contractName?: string;
+    implAddress?: string; // populated when we resolved this address as a proxy
+  }
+
+  // Single ABI item keyed by its keccak hash (4-byte selector for functions,
+  // 32-byte topic0 for events). Source: vechain/b32 keccak directory.
+  // `miss` records 404s so we don't refetch repeatedly.
+  export interface B32Signature {
+    id?: number;
+    hash: string; // 0x... lowercase
+    item: any | null;
+    miss?: boolean;
+    fetchedTime: number;
+  }
+
+  // Canonical signature from OpenChain (api.openchain.xyz). For events we
+  // store the signature string and rebuild an ABI item with a best-guess
+  // indexed pattern at decode time. `miss` records 404s.
+  export interface OpenChainSignature {
+    id?: number;
+    hash: string; // 0x... lowercase
+    kind: 'function' | 'event';
+    canonicalSignature: string | null;
+    miss?: boolean;
+    fetchedTime: number;
+  }
 }
 
 class Database extends Dexie {
@@ -70,6 +104,9 @@ class Database extends Dexie {
   public readonly networks!: Dexie.Table<Entities.Network, number>;
   public readonly customRoles!: Dexie.Table<Entities.CustomRole, number>;
   public readonly txBuilderDrafts!: Dexie.Table<Entities.TxBuilderDraft, number>;
+  public readonly sourcedAbis!: Dexie.Table<Entities.SourcedAbi, number>;
+  public readonly b32Signatures!: Dexie.Table<Entities.B32Signature, number>;
+  public readonly openchainSignatures!: Dexie.Table<Entities.OpenChainSignature, number>;
 
   constructor() {
     super("inspect");
@@ -101,6 +138,15 @@ class Database extends Dexie {
     });
     this.version(9).stores({
       txBuilderDrafts: "++id, name, network, updatedTime",
+    });
+    this.version(10).stores({
+      sourcedAbis: "++id, &[genesisId+address], genesisId, address",
+    });
+    this.version(11).stores({
+      b32Signatures: "++id, &hash",
+    });
+    this.version(12).stores({
+      openchainSignatures: "++id, &[hash+kind], hash, kind",
     });
     this.open().catch((err) => {
       // tslint:disable-next-line:no-console

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import router from './Router'
 import './overwrite.css'
 import VueAnalytics from 'vue-analytics'
 import Connex from '@vechain/connex'
-import { createConnex, createConnexForNetwork, isSoloNode } from './create-connex'
+import { createConnex, createConnexForNetwork, isSoloNode, nodeUrls } from './create-connex'
 import { prePopulate } from '@/pre-populate'
 import { getNetworkById } from './services/network-service'
 import { isCustomNetwork, getCustomNetworkId } from './utils'
@@ -23,6 +23,7 @@ declare module 'vue/types/vue' {
     $explorerAccount: string
     $explorerBlock: string
     $explorerTx: string
+    $nodeUrl: string
   }
 }
 
@@ -59,6 +60,7 @@ async function initApp() {
   if (['test', 'main', 'solo'].includes(net)) {
     setExplorerUrl(net)
     Vue.prototype.$connex = createConnex(net as "test" | "main" | "solo")
+    Vue.prototype.$nodeUrl = nodeUrls[net as "test" | "main" | "solo"]
   } else if (isCustomNetwork(net)) {
       const networkId = getCustomNetworkId(net)
       if (networkId) {
@@ -90,17 +92,20 @@ async function initApp() {
             Vue.prototype.$explorerTx = `${host}transactions/`
 
             Vue.prototype.$connex = createConnexForNetwork(customNetwork.nodeUrl, genesisBlock, genesisBlock.id)
+            Vue.prototype.$nodeUrl = customNetwork.nodeUrl
           } else {
             console.error('Custom network not found, falling back to mainnet')
             localStorage.setItem('last-net', 'main')
             setExplorerUrl('main')
             Vue.prototype.$connex = createConnex('main')
+            Vue.prototype.$nodeUrl = nodeUrls.main
           }
         } catch (error) {
           console.error('Failed to load custom network:', error)
           localStorage.setItem('last-net', 'main')
           setExplorerUrl('main')
           Vue.prototype.$connex = createConnex('main')
+          Vue.prototype.$nodeUrl = (await import('./create-connex')).nodeUrls.main
         }
       }
     } else {
@@ -121,6 +126,7 @@ async function initApp() {
           Vue.prototype.$explorerTx = `${host}transactions/`
         }
         Vue.prototype.$connex = createConnexForNetwork(node, network, network.id)
+        Vue.prototype.$nodeUrl = node
       }
     }
 

--- a/src/services/b32-service.ts
+++ b/src/services/b32-service.ts
@@ -1,0 +1,107 @@
+// vechain/b32 signature lookup.
+//
+// b32 maintains a per-keccak ABI item directory at
+// `/ABIs/keccak/0x<hash>.json` — keyed by:
+//   * 4-byte function selectors (function items)
+//   * 32-byte event topic0s    (event items)
+//
+// We use this as a fallback when our local registry (user-imported + built-in
+// b32 contract ABIs + Sourcify) can't decode a selector / topic0. Even when
+// we don't have the parent contract, b32 usually has the canonical signature,
+// which is enough to render a useful "this is `transfer(address,uint256)`"
+// answer and to decode arguments.
+//
+// Persistent cache in DB.b32Signatures, with negative caching for 404s so we
+// don't retry every panel mount.
+
+import DB, { Entities } from '../database'
+
+const B32_BASE = 'https://raw.githubusercontent.com/vechain/b32/refs/heads/master/ABIs/keccak'
+
+const inflight = new Map<string, Promise<Entities.B32Signature | null>>()
+
+function normalizeHash(hash: string): string {
+    return hash.toLowerCase()
+}
+
+async function fetchFromB32(hash: string): Promise<any | null> {
+    const url = `${B32_BASE}/${hash}.json`
+    let res: Response
+    try {
+        res = await fetch(url)
+    } catch {
+        return null
+    }
+    if (!res.ok) return null
+    try {
+        return await res.json()
+    } catch {
+        return null
+    }
+}
+
+// Returns the cached or freshly-fetched B32Signature row for the given hash.
+// Returns null if b32 has no entry (after caching the miss).
+export async function fetchSignature(hash: string): Promise<Entities.B32Signature | null> {
+    const key = normalizeHash(hash)
+    const pending = inflight.get(key)
+    if (pending) return pending
+
+    const promise = (async () => {
+        const existing = await DB.b32Signatures.where('hash').equals(key).first()
+        if (existing) {
+            // Negative cache hit — treat as no match.
+            if (existing.miss) return null
+            return existing
+        }
+
+        const item = await fetchFromB32(key)
+
+        if (!item) {
+            // Persist the miss so repeat lookups are instant.
+            const missEntry: Entities.B32Signature = {
+                hash: key,
+                item: null,
+                miss: true,
+                fetchedTime: Date.now()
+            }
+            try {
+                await DB.b32Signatures.add(missEntry)
+            } catch {
+                // Concurrent insert race — ignore.
+            }
+            return null
+        }
+
+        const entry: Entities.B32Signature = {
+            hash: key,
+            item,
+            fetchedTime: Date.now()
+        }
+        try {
+            const id = await DB.b32Signatures.add(entry)
+            entry.id = typeof id === 'number' ? id : undefined
+        } catch {
+            const fresh = await DB.b32Signatures.where('hash').equals(key).first()
+            if (fresh && !fresh.miss) return fresh
+        }
+        return entry
+    })()
+
+    inflight.set(key, promise)
+    try {
+        return await promise
+    } finally {
+        const resolved = await promise.catch(() => null)
+        if (!resolved) inflight.delete(key)
+    }
+}
+
+// Convenience: builds a canonical signature like "transfer(address,uint256)"
+// from a b32 ABI item.
+export function canonicalSignature(item: any): string {
+    if (!item || !item.name) return ''
+    const inputs = Array.isArray(item.inputs) ? item.inputs : []
+    const types = inputs.map((i: any) => i.type || '').join(',')
+    return `${item.name}(${types})`
+}

--- a/src/services/debug-service.ts
+++ b/src/services/debug-service.ts
@@ -1,0 +1,175 @@
+// Thin REST wrapper for Thor endpoints that Connex doesn't expose with the
+// options we need (e.g. simulating clauses at an arbitrary revision, or hitting
+// /debug/tracers). All callers must pass an explicit nodeUrl — typically
+// Vue.prototype.$nodeUrl from main.ts.
+
+export interface SimulateClause {
+    to: string | null
+    value: string
+    data: string
+}
+
+export interface SimulateOptions {
+    caller?: string
+    gas?: number
+    gasPayer?: string
+}
+
+export interface SimulateOutput {
+    data: string
+    events: Array<{ address: string; topics: string[]; data: string }>
+    transfers: Array<{ sender: string; recipient: string; amount: string }>
+    gasUsed: number
+    reverted: boolean
+    vmError?: string
+}
+
+function joinUrl(base: string, path: string): string {
+    const b = base.endsWith('/') ? base.slice(0, -1) : base
+    return b + path
+}
+
+// POST /accounts/*?revision={revision}
+//
+// `revision` accepts a block ID, block number, or 'best'. Simulating at
+// `blockNumber - 1` of the failing tx's block gives the pre-tx state — close
+// enough to reproduce most reverts, but won't catch intra-block dependencies.
+export async function simulateClauses(
+    nodeUrl: string,
+    clauses: SimulateClause[],
+    options: SimulateOptions,
+    revision: string | number
+): Promise<SimulateOutput[]> {
+    const url = joinUrl(nodeUrl, `/accounts/*?revision=${encodeURIComponent(String(revision))}`)
+    const body: any = { clauses }
+    if (options.caller) body.caller = options.caller
+    if (options.gas) body.gas = options.gas
+    if (options.gasPayer) body.gasPayer = options.gasPayer
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    })
+    if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`Simulation failed (${res.status}): ${text || res.statusText}`)
+    }
+    return res.json()
+}
+
+export interface AccountInfo {
+    balance: string  // VET in wei (hex string)
+    energy: string   // VTHO in wei (hex string)
+    hasCode: boolean
+}
+
+export async function getAccount(nodeUrl: string, address: string): Promise<AccountInfo> {
+    const res = await fetch(joinUrl(nodeUrl, `/accounts/${address}`))
+    if (!res.ok) {
+        throw new Error(`Failed to fetch account (${res.status})`)
+    }
+    return res.json()
+}
+
+export async function getAccountCode(nodeUrl: string, address: string): Promise<string> {
+    const res = await fetch(joinUrl(nodeUrl, `/accounts/${address}/code`))
+    if (!res.ok) {
+        throw new Error(`Failed to fetch code (${res.status})`)
+    }
+    const json = await res.json()
+    return (json && json.code) || '0x'
+}
+
+export async function getStorage(nodeUrl: string, address: string, key: string): Promise<string> {
+    const res = await fetch(joinUrl(nodeUrl, `/accounts/${address}/storage/${key}`))
+    if (!res.ok) {
+        throw new Error(`Failed to read storage (${res.status})`)
+    }
+    const json = await res.json()
+    return (json && json.value) || '0x' + '00'.repeat(32)
+}
+
+export interface BlockSummary {
+    id: string
+    number: number
+    timestamp: number
+    transactions: string[]
+}
+
+export async function getBlock(nodeUrl: string, revision: string | number): Promise<BlockSummary | null> {
+    const res = await fetch(joinUrl(nodeUrl, `/blocks/${encodeURIComponent(String(revision))}`))
+    if (!res.ok) {
+        if (res.status === 404) return null
+        throw new Error(`Failed to fetch block (${res.status})`)
+    }
+    return res.json()
+}
+
+// Track tracer-endpoint availability per node URL so we don't hammer the
+// endpoint when it's disabled.
+const tracerAvailability = new Map<string, Promise<boolean>>()
+
+export interface TraceCallFrame {
+    type: string                  // CALL, STATICCALL, DELEGATECALL, CREATE, etc.
+    from: string
+    to?: string
+    value?: string
+    gas?: string
+    gasUsed?: string
+    input?: string
+    output?: string
+    error?: string
+    revertReason?: string
+    calls?: TraceCallFrame[]
+}
+
+// Probes the /debug/tracers endpoint by attempting a tiny call-trace request.
+// Cached per nodeUrl for the session.
+export function isTracerAvailable(nodeUrl: string, sampleTarget: string): Promise<boolean> {
+    const existing = tracerAvailability.get(nodeUrl)
+    if (existing) return existing
+    const probe = (async () => {
+        try {
+            const url = joinUrl(nodeUrl, '/debug/tracers')
+            const res = await fetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: 'call', target: sampleTarget })
+            })
+            // Some nodes return 403 / 404 / 501 when /debug is disabled.
+            if (res.status === 403 || res.status === 404 || res.status === 501) {
+                return false
+            }
+            // 400 means the endpoint is up but the target string was bad —
+            // which is fine, the endpoint exists.
+            return true
+        } catch {
+            return false
+        }
+    })()
+    tracerAvailability.set(nodeUrl, probe)
+    return probe
+}
+
+export async function traceClauseCall(
+    nodeUrl: string,
+    blockId: string,
+    txIndex: number,
+    clauseIndex: number
+): Promise<TraceCallFrame> {
+    const url = joinUrl(nodeUrl, '/debug/tracers')
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            name: 'call',
+            target: `${blockId}/${txIndex}/${clauseIndex}`
+        })
+    })
+    if (!res.ok) {
+        const text = await res.text().catch(() => '')
+        throw new Error(`Tracer failed (${res.status}): ${text || res.statusText}`)
+    }
+    return res.json()
+}

--- a/src/services/openchain-service.ts
+++ b/src/services/openchain-service.ts
@@ -1,0 +1,300 @@
+// OpenChain signature lookup.
+//
+// OpenChain (api.openchain.xyz) hosts a massive cross-chain signature DB
+// scraped from Ethereum and other EVM chains. We use it as a fallback for
+// VeChain contracts that don't have b32 entries — common for forks of
+// Ethereum protocols (Uniswap-style DEXes, Aave-style lending, etc.) where
+// the selectors/topics match Ethereum but b32 hasn't catalogued the fork.
+//
+// OpenChain returns canonical signatures only (e.g. `transfer(address,uint256)`),
+// not full ABI items. We parse the signature back into an ABI item so the
+// existing decoders work — for events we have to guess the indexed pattern
+// since canonical sigs don't carry that info.
+
+import DB, { Entities } from '../database'
+
+const OPENCHAIN_URL = 'https://api.openchain.xyz/signature-database/v1/lookup'
+
+const inflight = new Map<string, Promise<Entities.OpenChainSignature | null>>()
+
+function cacheKey(kind: 'function' | 'event', hash: string): string {
+    return `${kind}:${hash.toLowerCase()}`
+}
+
+interface OpenChainResponse {
+    ok?: boolean
+    result?: {
+        function?: Record<string, Array<{ name: string; filtered?: boolean }> | null>
+        event?: Record<string, Array<{ name: string; filtered?: boolean }> | null>
+    }
+}
+
+// Picks the best canonical signature from OpenChain's response. Multiple
+// matches are common (selector collisions); we drop entries flagged
+// `filtered` (auto-generated names like `func_a1b2c3d4()`) and take the
+// first remaining hit — OpenChain returns them in popularity-ish order.
+function pickBestSignature(entries: Array<{ name: string; filtered?: boolean }> | null | undefined): string | null {
+    if (!entries || entries.length === 0) return null
+    const usable = entries.filter((e) => !e.filtered)
+    const list = usable.length > 0 ? usable : entries
+    return list[0].name
+}
+
+async function fetchFromOpenChain(
+    kind: 'function' | 'event',
+    hash: string
+): Promise<string | null> {
+    const params = new URLSearchParams()
+    params.set(kind, hash)
+    const url = `${OPENCHAIN_URL}?${params.toString()}&filter=true`
+    let res: Response
+    try {
+        res = await fetch(url)
+    } catch {
+        return null
+    }
+    if (!res.ok) return null
+    let data: OpenChainResponse
+    try {
+        data = await res.json()
+    } catch {
+        return null
+    }
+    if (!data || !data.ok || !data.result) return null
+    const bucket = kind === 'function' ? data.result.function : data.result.event
+    if (!bucket) return null
+    return pickBestSignature(bucket[hash.toLowerCase()])
+}
+
+export async function fetchSignature(
+    kind: 'function' | 'event',
+    hash: string
+): Promise<Entities.OpenChainSignature | null> {
+    const key = cacheKey(kind, hash)
+    const pending = inflight.get(key)
+    if (pending) return pending
+
+    const promise = (async () => {
+        const normalized = hash.toLowerCase()
+        const existing = await DB.openchainSignatures
+            .where('[hash+kind]')
+            .equals([normalized, kind])
+            .first()
+        if (existing) {
+            return existing.miss ? null : existing
+        }
+
+        const sig = await fetchFromOpenChain(kind, normalized)
+
+        if (!sig) {
+            try {
+                await DB.openchainSignatures.add({
+                    hash: normalized,
+                    kind,
+                    canonicalSignature: null,
+                    miss: true,
+                    fetchedTime: Date.now()
+                })
+            } catch { /* race — ignore */ }
+            return null
+        }
+
+        const entry: Entities.OpenChainSignature = {
+            hash: normalized,
+            kind,
+            canonicalSignature: sig,
+            fetchedTime: Date.now()
+        }
+        try {
+            const id = await DB.openchainSignatures.add(entry)
+            entry.id = typeof id === 'number' ? id : undefined
+        } catch {
+            const fresh = await DB.openchainSignatures
+                .where('[hash+kind]')
+                .equals([normalized, kind])
+                .first()
+            if (fresh && !fresh.miss) return fresh
+        }
+        return entry
+    })()
+
+    inflight.set(key, promise)
+    try {
+        return await promise
+    } finally {
+        const resolved = await promise.catch(() => null)
+        if (!resolved) inflight.delete(key)
+    }
+}
+
+// Batched lookup. Significantly faster than calling fetchSignature in a loop:
+// one HTTP request can resolve up to ~50 hashes at once. Cached entries (hits
+// and misses) are returned without hitting the network.
+export async function fetchSignatures(
+    kind: 'function' | 'event',
+    hashes: string[]
+): Promise<Map<string, Entities.OpenChainSignature>> {
+    const out = new Map<string, Entities.OpenChainSignature>()
+    if (hashes.length === 0) return out
+
+    const normalized = Array.from(new Set(hashes.map((h) => h.toLowerCase())))
+    const uncached: string[] = []
+
+    // First pass: read the cache for everything we already know.
+    await Promise.all(
+        normalized.map(async (hash) => {
+            const existing = await DB.openchainSignatures
+                .where('[hash+kind]')
+                .equals([hash, kind])
+                .first()
+            if (existing) {
+                if (!existing.miss) out.set(hash, existing)
+            } else {
+                uncached.push(hash)
+            }
+        })
+    )
+
+    if (uncached.length === 0) return out
+
+    // Chunk to keep URL length sane and respect any per-request limit. 50
+    // function selectors (10 chars each + commas) ≈ 560 chars of query
+    // string, well under the safe ~2KB limit.
+    const CHUNK = 50
+    const chunks: string[][] = []
+    for (let i = 0; i < uncached.length; i += CHUNK) {
+        chunks.push(uncached.slice(i, i + CHUNK))
+    }
+
+    const now = Date.now()
+
+    await Promise.all(
+        chunks.map(async (chunk) => {
+            const params = new URLSearchParams()
+            params.set(kind, chunk.join(','))
+            params.set('filter', 'true')
+            const url = `${OPENCHAIN_URL}?${params.toString()}`
+            let res: Response
+            try {
+                res = await fetch(url)
+            } catch {
+                return
+            }
+            if (!res.ok) return
+            let data: OpenChainResponse
+            try {
+                data = await res.json()
+            } catch {
+                return
+            }
+            if (!data || !data.ok || !data.result) return
+            const bucket = kind === 'function' ? data.result.function : data.result.event
+            if (!bucket) return
+
+            // Persist hits and misses individually so each becomes a cached
+            // future lookup. We add() instead of put() so concurrent inserts
+            // are ignored (compound unique index prevents duplicates).
+            for (const hash of chunk) {
+                const sig = pickBestSignature(bucket[hash])
+                if (sig) {
+                    const entry: Entities.OpenChainSignature = {
+                        hash,
+                        kind,
+                        canonicalSignature: sig,
+                        fetchedTime: now
+                    }
+                    try {
+                        const id = await DB.openchainSignatures.add(entry)
+                        entry.id = typeof id === 'number' ? id : undefined
+                    } catch { /* race — ignore */ }
+                    out.set(hash, entry)
+                } else {
+                    try {
+                        await DB.openchainSignatures.add({
+                            hash,
+                            kind,
+                            canonicalSignature: null,
+                            miss: true,
+                            fetchedTime: now
+                        })
+                    } catch { /* race — ignore */ }
+                }
+            }
+        })
+    )
+
+    return out
+}
+
+// Splits a comma-separated arg list at the top level (respecting nested
+// tuples). `address,(uint256,uint256)[],bytes` → ['address', '(uint256,uint256)[]', 'bytes']
+function splitTopLevelCommas(s: string): string[] {
+    const out: string[] = []
+    let depth = 0
+    let cur = ''
+    for (const ch of s) {
+        if (ch === '(' || ch === '[') depth++
+        else if (ch === ')' || ch === ']') depth--
+        if (ch === ',' && depth === 0) {
+            const trimmed = cur.trim()
+            if (trimmed) out.push(trimmed)
+            cur = ''
+        } else {
+            cur += ch
+        }
+    }
+    const tail = cur.trim()
+    if (tail) out.push(tail)
+    return out
+}
+
+// Parses a canonical signature like `transfer(address,uint256)` into a name
+// and arg-type list.
+export function parseSignature(sig: string): { name: string; types: string[] } | null {
+    const m = sig.match(/^([^\s(]+)\((.*)\)$/)
+    if (!m) return null
+    const name = m[1]
+    const argsStr = m[2]
+    if (!argsStr) return { name, types: [] }
+    return { name, types: splitTopLevelCommas(argsStr) }
+}
+
+// Builds a function ABI item from a canonical signature.
+export function signatureToFunctionItem(sig: string): any | null {
+    const parsed = parseSignature(sig)
+    if (!parsed) return null
+    return {
+        type: 'function',
+        name: parsed.name,
+        stateMutability: 'nonpayable',
+        inputs: parsed.types.map((t, i) => ({ name: `arg${i}`, type: t })),
+        outputs: []
+    }
+}
+
+// Builds an event ABI item from a canonical signature with a best-guess
+// indexed pattern. `numIndexed` should match `log.topics.length - 1`. By
+// convention indexed params come first (OZ standard), which is what we
+// emit here. Caller should also try the reverse pattern if decode fails.
+export function signatureToEventItem(sig: string, numIndexed: number, indexedFromEnd = false): any | null {
+    const parsed = parseSignature(sig)
+    if (!parsed) return null
+    const n = parsed.types.length
+    if (numIndexed > n) return null
+    const indexedAt = new Set<number>()
+    if (indexedFromEnd) {
+        for (let i = n - numIndexed; i < n; i++) indexedAt.add(i)
+    } else {
+        for (let i = 0; i < numIndexed; i++) indexedAt.add(i)
+    }
+    return {
+        type: 'event',
+        name: parsed.name,
+        anonymous: false,
+        inputs: parsed.types.map((t, i) => ({
+            name: `arg${i}`,
+            type: t,
+            indexed: indexedAt.has(i)
+        }))
+    }
+}

--- a/src/services/sourcify-service.ts
+++ b/src/services/sourcify-service.ts
@@ -1,0 +1,193 @@
+// Sourcify fallback for verified contract ABIs.
+//
+// When the local registry (user-imported + b32 built-ins) doesn't match a
+// selector / topic0 / error selector, we try fetching the ABI from Sourcify
+// by chain ID + address. Successes are cached in the sourcedAbis Dexie table
+// so they persist across reloads.
+//
+// Network failures, 404s, and unsupported chains all fail silently — callers
+// should treat null as "we tried and got nothing."
+
+import DB, { Entities } from '../database'
+import { getStorage } from './debug-service'
+
+const SOURCIFY_SERVER = 'https://sourcify.dev/server'
+
+// VeChain chain IDs as registered with Sourcify.
+const CHAIN_IDS_BY_GENESIS: Record<string, number> = {
+    '0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a': 100009, // mainnet
+    '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127': 100010  // testnet
+}
+
+// EIP-1967 implementation slot.
+const SLOT_IMPL = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
+
+function slotToAddress(slotValue: string): string | null {
+    if (!slotValue || !slotValue.startsWith('0x')) return null
+    const hex = slotValue.slice(2).padStart(64, '0')
+    const addr = '0x' + hex.slice(24)
+    if (/^0x0+$/.test(addr)) return null
+    return addr.toLowerCase()
+}
+
+// Dedupes concurrent fetches for the same address within the session.
+const inflight = new Map<string, Promise<Entities.SourcedAbi | null>>()
+
+function cacheKey(genesisId: string, address: string): string {
+    return `${genesisId}:${address.toLowerCase()}`
+}
+
+interface SourcifyFile {
+    name: string
+    path?: string
+    content?: string
+}
+
+interface SourcifyResponse {
+    status?: string
+    files?: SourcifyFile[]
+}
+
+interface ContractMetadata {
+    output?: {
+        abi?: any[]
+    }
+    settings?: {
+        compilationTarget?: Record<string, string>
+    }
+}
+
+function extractAbiFromFiles(files: SourcifyFile[]): { abi: any[]; name?: string } | null {
+    const metadataFile = files.find(
+        (f) => f.name === 'metadata.json' || (f.path && f.path.endsWith('/metadata.json'))
+    )
+    if (!metadataFile || !metadataFile.content) return null
+    try {
+        const meta = JSON.parse(metadataFile.content) as ContractMetadata
+        if (meta && meta.output && Array.isArray(meta.output.abi)) {
+            const target = meta.settings && meta.settings.compilationTarget
+            const targetName = target ? Object.values(target)[0] : undefined
+            return { abi: meta.output.abi, name: targetName }
+        }
+    } catch {
+        // malformed metadata
+    }
+    return null
+}
+
+async function fetchFromSourcify(
+    chainId: number,
+    address: string
+): Promise<{ abi: any[]; name?: string } | null> {
+    const url = `${SOURCIFY_SERVER}/files/any/${chainId}/${address}`
+    let res: Response
+    try {
+        res = await fetch(url)
+    } catch {
+        return null
+    }
+    if (!res.ok) return null
+    let data: SourcifyResponse
+    try {
+        data = await res.json()
+    } catch {
+        return null
+    }
+    if (!data || !Array.isArray(data.files)) return null
+    return extractAbiFromFiles(data.files)
+}
+
+async function readImplAddress(nodeUrl: string, address: string): Promise<string | null> {
+    try {
+        const slot = await getStorage(nodeUrl, address, SLOT_IMPL)
+        return slotToAddress(slot)
+    } catch {
+        return null
+    }
+}
+
+export interface FetchOptions {
+    // If provided, we read the EIP-1967 implementation slot first and prefer
+    // the impl's ABI. This is essential for OZ TransparentUpgradeableProxy /
+    // UUPS contracts (e.g. all VeBetterDAO deployments) — Sourcify has the
+    // impl verified, not the proxy wrapper.
+    nodeUrl?: string
+}
+
+// Returns a SourcedAbi entry for the given (genesis, address) — from the
+// persistent cache if known, otherwise fetched from Sourcify and persisted.
+// Returns null on miss (no record, no Sourcify entry, or chain unsupported).
+export async function fetchAbiForAddress(
+    genesisId: string,
+    address: string,
+    options: FetchOptions = {}
+): Promise<Entities.SourcedAbi | null> {
+    const key = cacheKey(genesisId, address)
+    const pending = inflight.get(key)
+    if (pending) return pending
+
+    const promise = (async () => {
+        const normalized = address.toLowerCase()
+        const existing = await DB.sourcedAbis
+            .where('[genesisId+address]')
+            .equals([genesisId, normalized])
+            .first()
+        if (existing) return existing
+
+        const chainId = CHAIN_IDS_BY_GENESIS[genesisId]
+        if (!chainId) return null
+
+        // Prefer impl ABI when this address is an EIP-1967 proxy.
+        let implAddress: string | undefined
+        let result: { abi: any[]; name?: string } | null = null
+        if (options.nodeUrl) {
+            const impl = await readImplAddress(options.nodeUrl, normalized)
+            if (impl) {
+                implAddress = impl
+                result = await fetchFromSourcify(chainId, impl)
+            }
+        }
+
+        // Either not a proxy, or impl wasn't on Sourcify — try the address itself.
+        if (!result) {
+            result = await fetchFromSourcify(chainId, normalized)
+        }
+        if (!result) return null
+
+        const entry: Entities.SourcedAbi = {
+            genesisId,
+            address: normalized,
+            abi: result.abi,
+            source: 'sourcify',
+            fetchedTime: Date.now(),
+            contractName: result.name,
+            implAddress
+        }
+        try {
+            const id = await DB.sourcedAbis.add(entry)
+            entry.id = typeof id === 'number' ? id : undefined
+        } catch {
+            // Concurrent insert race — re-read.
+            const fresh = await DB.sourcedAbis
+                .where('[genesisId+address]')
+                .equals([genesisId, normalized])
+                .first()
+            if (fresh) return fresh
+        }
+        return entry
+    })()
+
+    inflight.set(key, promise)
+    try {
+        return await promise
+    } finally {
+        // Keep successful hits in flight cache so repeated calls within the
+        // session resolve immediately; clear failures so retries are possible.
+        const resolved = await promise.catch(() => null)
+        if (!resolved) inflight.delete(key)
+    }
+}
+
+export async function loadSourcedAbis(genesisId: string): Promise<Entities.SourcedAbi[]> {
+    return DB.sourcedAbis.where('genesisId').equals(genesisId).toArray()
+}

--- a/src/utils/abi-registry.ts
+++ b/src/utils/abi-registry.ts
@@ -1,0 +1,625 @@
+import { abi } from 'thor-devkit'
+import DB, { Entities } from '../database'
+import { BuiltInContractsService } from '../services/builtin-contracts-service'
+import { fetchAbiForAddress, loadSourcedAbis } from '../services/sourcify-service'
+
+export interface ContractRef {
+    name: string
+    address: string
+}
+
+export interface EventHit {
+    kind: 'event'
+    topic0: string
+    canonicalName: string
+    definition: abi.Event.Definition
+    contract: ContractRef
+}
+
+export interface FunctionHit {
+    kind: 'function'
+    selector: string
+    canonicalName: string
+    definition: abi.Function.Definition
+    contract: ContractRef
+}
+
+export type RegistryHit = EventHit | FunctionHit
+
+interface AbiItem {
+    type?: string
+    name?: string
+    inputs?: any[]
+    outputs?: any[]
+    anonymous?: boolean
+    stateMutability?: string
+    constant?: boolean
+    payable?: boolean
+}
+
+// Loads imported contracts for the given network (matches Contracts.vue's filter:
+// `item.network === genesisId || item.network === undefined`).
+export async function loadNetworkContracts(genesisId: string): Promise<Entities.Contract[]> {
+    return DB.contracts
+        .filter((item) => item.network === genesisId || item.network === undefined)
+        .toArray()
+}
+
+// Cache built-in resolution per genesis ID so we don't refetch ~30 ABIs on
+// every panel mount. ABIs themselves are also cached inside BuiltInContractsService.
+const builtinCache = new Map<string, Promise<Entities.Contract[]>>()
+
+async function loadBuiltinContracts(genesisId: string): Promise<Entities.Contract[]> {
+    let p = builtinCache.get(genesisId)
+    if (!p) {
+        p = (async () => {
+            const results = await BuiltInContractsService.getBuiltInContracts(genesisId)
+            return results
+                .filter((r) => r.success && r.contract)
+                .map((r) => ({
+                    name: r.contract!.name,
+                    address: r.contract!.address || '',
+                    abi: r.contract!.abi,
+                    network: genesisId
+                }))
+        })()
+        builtinCache.set(genesisId, p)
+    }
+    return p
+}
+
+function sourcedAsContract(s: Entities.SourcedAbi): Entities.Contract {
+    return {
+        name: s.contractName || `Sourcify (${s.address.slice(0, 10)}…)`,
+        address: s.address,
+        abi: s.abi,
+        network: s.genesisId
+    }
+}
+
+// Loads imported contracts + built-in / curated contract ABIs + previously
+// Sourcify-fetched ABIs for the given network. Use this for any decode /
+// lookup work in the Debugger so users see hits against well-known contracts
+// even before they import anything.
+export async function loadAllContracts(genesisId: string): Promise<Entities.Contract[]> {
+    const [imported, builtins, sourced] = await Promise.all([
+        loadNetworkContracts(genesisId),
+        loadBuiltinContracts(genesisId),
+        loadSourcedAbis(genesisId)
+    ])
+    // Imported first so user-named contracts win on duplicate-address matches.
+    return [...imported, ...builtins, ...sourced.map(sourcedAsContract)]
+}
+
+// Attempts to fetch ABIs from Sourcify for any address not already covered
+// by the local registry. When nodeUrl is provided, EIP-1967 proxy addresses
+// are resolved to their implementation before querying Sourcify (essential
+// for OZ-upgradeable contracts like all of VeBetterDAO's). Successes are
+// persisted to DB. Returns a refreshed contracts list.
+export async function ensureAbisForAddresses(
+    genesisId: string,
+    addresses: Array<string | null | undefined>,
+    nodeUrl?: string
+): Promise<Entities.Contract[]> {
+    const current = await loadAllContracts(genesisId)
+    const have = new Set(
+        current
+            .map((c) => (c.address || '').toLowerCase())
+            .filter((a) => a)
+    )
+
+    const targets = Array.from(
+        new Set(
+            addresses
+                .filter((a): a is string => !!a && a !== '0x' && /^0x[0-9a-fA-F]{40}$/.test(a))
+                .map((a) => a.toLowerCase())
+                .filter((a) => !have.has(a))
+        )
+    )
+    if (targets.length === 0) return current
+
+    let fetchedAny = false
+    await Promise.all(
+        targets.map(async (addr) => {
+            const hit = await fetchAbiForAddress(genesisId, addr, { nodeUrl })
+            if (hit) fetchedAny = true
+        })
+    )
+    if (!fetchedAny) return current
+    return loadAllContracts(genesisId)
+}
+
+function asArray(maybeAbi: object | any[] | undefined): AbiItem[] {
+    if (!maybeAbi) return []
+    if (Array.isArray(maybeAbi)) return maybeAbi as AbiItem[]
+    return []
+}
+
+// Decode an event log using a raw event ABI item that isn't attached to any
+// contract in our registry — e.g. one fetched directly from the b32 keccak DB.
+// Returns null on malformed or unmatched data.
+export function decodeLogWithAbiItem(
+    log: { address: string; topics: string[]; data: string },
+    item: any
+): DecodedLog | null {
+    if (!item || item.type !== 'event' || item.anonymous) return null
+    try {
+        const ev = new abi.Event(item as abi.Event.Definition)
+        if (ev.signature.toLowerCase() !== (log.topics[0] || '').toLowerCase()) return null
+        const decoded = ev.decode(log.data, log.topics)
+        const args = (item.inputs || []).map((inp: any, i: number) => ({
+            name: inp.name || `arg${i}`,
+            type: inp.type,
+            indexed: !!inp.indexed,
+            value: decoded[i]
+        }))
+        return {
+            canonicalName: ev.canonicalName,
+            eventName: item.name,
+            args,
+            contract: { name: 'b32 signature', address: log.address }
+        }
+    } catch {
+        return null
+    }
+}
+
+// Decode calldata using a raw function ABI item — same idea as above but for
+// function selectors matched in the b32 keccak DB without a parent contract.
+export function decodeCalldataWithAbiItem(
+    calldata: string,
+    item: any
+): DecodedCall | null {
+    if (!item || item.type !== 'function') return null
+    if (!calldata || calldata.length < 10) return null
+    try {
+        const fn = new abi.Function(item as abi.Function.Definition)
+        if (fn.signature.toLowerCase() !== calldata.slice(0, 10).toLowerCase()) return null
+        const argsHex = '0x' + calldata.slice(10)
+        const inputs = item.inputs || []
+        const decoded = inputs.length ? abi.decodeParameters(inputs, argsHex) : ({} as any)
+        const args = inputs.map((inp: any, i: number) => ({
+            name: inp.name || `arg${i}`,
+            type: inp.type,
+            value: decoded[i]
+        }))
+        return {
+            canonicalName: fn.canonicalName,
+            fnName: item.name,
+            args,
+            contract: { name: 'b32 signature', address: '' }
+        }
+    } catch {
+        return null
+    }
+}
+
+export function lookupByTopic0(
+    contracts: Entities.Contract[],
+    topic0: string
+): EventHit[] {
+    const needle = topic0.toLowerCase()
+    const hits: EventHit[] = []
+    for (const c of contracts) {
+        const items = asArray(c.abi)
+        for (const item of items) {
+            if (item.type !== 'event' || item.anonymous) continue
+            try {
+                const ev = new abi.Event(item as abi.Event.Definition)
+                if (ev.signature.toLowerCase() === needle) {
+                    hits.push({
+                        kind: 'event',
+                        topic0: ev.signature.toLowerCase(),
+                        canonicalName: ev.canonicalName,
+                        definition: item as abi.Event.Definition,
+                        contract: { name: c.name || '(unnamed)', address: c.address }
+                    })
+                }
+            } catch {
+                // Malformed event in this ABI — skip.
+            }
+        }
+    }
+    return hits
+}
+
+export interface DecodedCall {
+    canonicalName: string
+    fnName: string
+    args: Array<{ name: string; type: string; value: any }>
+    contract: ContractRef
+}
+
+export interface DecodedLog {
+    canonicalName: string
+    eventName: string
+    args: Array<{ name: string; type: string; indexed: boolean; value: any }>
+    contract: ContractRef
+}
+
+export function findContractByAddress(
+    contracts: Entities.Contract[],
+    address: string
+): Entities.Contract | null {
+    const needle = address.toLowerCase()
+    return contracts.find((c) => (c.address || '').toLowerCase() === needle) || null
+}
+
+export function decodeCalldata(
+    contracts: Entities.Contract[],
+    targetAddress: string | null | undefined,
+    calldata: string
+): DecodedCall | null {
+    if (!calldata || calldata.length < 10) return null
+    const selector = calldata.slice(0, 10).toLowerCase()
+
+    // Prefer the function defined on the target contract; fall back to any
+    // contract that has a matching selector (handy for proxies/diamonds).
+    let chosen: { item: AbiItem; fn: abi.Function; contract: Entities.Contract } | null = null
+
+    const target = targetAddress
+        ? findContractByAddress(contracts, targetAddress)
+        : null
+
+    const search = (c: Entities.Contract) => {
+        const items = asArray(c.abi)
+        for (const item of items) {
+            if (item.type !== 'function') continue
+            try {
+                const fn = new abi.Function(item as abi.Function.Definition)
+                if (fn.signature.toLowerCase() === selector) {
+                    chosen = { item, fn, contract: c }
+                    return true
+                }
+            } catch {
+                // skip
+            }
+        }
+        return false
+    }
+
+    if (target) {
+        search(target)
+    }
+    if (!chosen) {
+        for (const c of contracts) {
+            if (search(c)) break
+        }
+    }
+    if (!chosen) return null
+
+    const def = (chosen as any).item as abi.Function.Definition
+    const fnObj = (chosen as any).fn as abi.Function
+    const contractEntry = (chosen as any).contract as Entities.Contract
+
+    try {
+        const argsHex = '0x' + calldata.slice(10)
+        const decoded = abi.decodeParameters(def.inputs as any[], argsHex)
+        const args = (def.inputs || []).map((inp, i) => ({
+            name: inp.name || `arg${i}`,
+            type: inp.type,
+            value: decoded[i]
+        }))
+        return {
+            canonicalName: fnObj.canonicalName,
+            fnName: def.name,
+            args,
+            contract: {
+                name: contractEntry.name || '(unnamed)',
+                address: contractEntry.address
+            }
+        }
+    } catch {
+        return null
+    }
+}
+
+// Solidity built-in revert selectors.
+const SELECTOR_ERROR_STRING = '0x08c379a0' // Error(string)
+const SELECTOR_PANIC = '0x4e487b71'        // Panic(uint256)
+
+const PANIC_CODES: Record<string, string> = {
+    '0x00': 'generic compiler-inserted panic',
+    '0x01': 'assert failed',
+    '0x11': 'arithmetic overflow or underflow',
+    '0x12': 'division or modulo by zero',
+    '0x21': 'invalid enum conversion',
+    '0x22': 'incorrectly encoded storage byte array',
+    '0x31': '.pop() on empty array',
+    '0x32': 'array index out of bounds',
+    '0x41': 'out of memory (oversized allocation)',
+    '0x51': 'invalid internal function call'
+}
+
+export type DecodedRevert =
+    | { kind: 'none' }
+    | { kind: 'empty' }
+    | { kind: 'string'; message: string }
+    | { kind: 'panic'; code: string; description: string }
+    | {
+          kind: 'custom'
+          name: string
+          canonicalName: string
+          args: Array<{ name: string; type: string; value: any }>
+          contract: ContractRef
+      }
+    | { kind: 'raw'; data: string }
+    // EVM-level halt (out of gas, invalid opcode, stack overflow, …) that
+    // surfaces in the call tracer as `error` with no decodable revert data.
+    | { kind: 'vm-error'; error: string; at?: { type: string; to?: string } }
+
+export function decodeRevertData(
+    contracts: Entities.Contract[],
+    targetAddress: string | null | undefined,
+    data: string
+): DecodedRevert {
+    if (!data || data === '0x') return { kind: 'empty' }
+    if (data.length < 10) return { kind: 'raw', data }
+
+    const selector = data.slice(0, 10).toLowerCase()
+    const argsHex = '0x' + data.slice(10)
+
+    if (selector === SELECTOR_ERROR_STRING) {
+        try {
+            const decoded = abi.decodeParameter('string', argsHex)
+            return { kind: 'string', message: String(decoded) }
+        } catch {
+            return { kind: 'raw', data }
+        }
+    }
+
+    if (selector === SELECTOR_PANIC) {
+        try {
+            const decoded = abi.decodeParameter('uint256', argsHex)
+            const codeNum = typeof decoded === 'string' ? parseInt(decoded, 10) : Number(decoded)
+            const codeHex = '0x' + codeNum.toString(16).padStart(2, '0')
+            return {
+                kind: 'panic',
+                code: codeHex,
+                description: PANIC_CODES[codeHex] || 'unknown panic code'
+            }
+        } catch {
+            return { kind: 'raw', data }
+        }
+    }
+
+    // Custom error — search ABI items where type==='error', preferring the
+    // target contract.
+    const target = targetAddress ? findContractByAddress(contracts, targetAddress) : null
+
+    let match: { item: AbiItem; contract: Entities.Contract } | null = null
+
+    const search = (c: Entities.Contract): boolean => {
+        const items = asArray(c.abi)
+        for (const item of items) {
+            if (item.type !== 'error') continue
+            try {
+                const fakeFn = new abi.Function({
+                    type: 'function',
+                    name: item.name || '',
+                    stateMutability: 'nonpayable',
+                    inputs: (item.inputs as any) || [],
+                    outputs: []
+                })
+                if (fakeFn.signature.toLowerCase() === selector) {
+                    match = { item, contract: c }
+                    return true
+                }
+            } catch {
+                // skip malformed
+            }
+        }
+        return false
+    }
+
+    if (target) search(target)
+    if (!match) {
+        for (const c of contracts) {
+            if (search(c)) break
+        }
+    }
+
+    if (!match) return { kind: 'raw', data }
+
+    const matchedItem = (match as any).item as AbiItem
+    const matchedContract = (match as any).contract as Entities.Contract
+
+    try {
+        const inputs = (matchedItem.inputs || []) as any[]
+        const decoded = inputs.length ? abi.decodeParameters(inputs, argsHex) : ({} as any)
+        const args = inputs.map((inp, i) => ({
+            name: inp.name || `arg${i}`,
+            type: inp.type,
+            value: decoded[i]
+        }))
+        const types = inputs.map((i) => i.type).join(',')
+        return {
+            kind: 'custom',
+            name: matchedItem.name || '(unnamed error)',
+            canonicalName: `${matchedItem.name || ''}(${types})`,
+            args,
+            contract: {
+                name: matchedContract.name || '(unnamed)',
+                address: matchedContract.address
+            }
+        }
+    } catch {
+        return { kind: 'raw', data }
+    }
+}
+
+export interface DecodedFrameCall {
+    fnName: string
+    canonicalName: string
+    contract: ContractRef
+    inputs: Array<{ name: string; type: string; value: any }>
+    outputs: Array<{ name: string; type: string; value: any }> | null
+}
+
+// Decodes a call frame's `input` (calldata) and `output` (return data) against
+// the same ABI function entry. Used by the internal-trace renderer.
+export function decodeFrameCall(
+    contracts: Entities.Contract[],
+    targetAddress: string | null | undefined,
+    calldata: string,
+    outputData?: string
+): DecodedFrameCall | null {
+    if (!calldata || calldata.length < 10) return null
+    const selector = calldata.slice(0, 10).toLowerCase()
+
+    let chosen: { item: AbiItem; fn: abi.Function; contract: Entities.Contract } | null = null
+    const target = targetAddress ? findContractByAddress(contracts, targetAddress) : null
+
+    const search = (c: Entities.Contract): boolean => {
+        const items = asArray(c.abi)
+        for (const item of items) {
+            if (item.type !== 'function') continue
+            try {
+                const fn = new abi.Function(item as abi.Function.Definition)
+                if (fn.signature.toLowerCase() === selector) {
+                    chosen = { item, fn, contract: c }
+                    return true
+                }
+            } catch { /* skip */ }
+        }
+        return false
+    }
+
+    if (target) search(target)
+    if (!chosen) {
+        for (const c of contracts) {
+            if (search(c)) break
+        }
+    }
+    if (!chosen) return null
+
+    const def = (chosen as any).item as abi.Function.Definition
+    const fnObj = (chosen as any).fn as abi.Function
+    const contractEntry = (chosen as any).contract as Entities.Contract
+
+    let inputs: DecodedFrameCall['inputs'] = []
+    try {
+        const argsHex = '0x' + calldata.slice(10)
+        const decodedInputs = abi.decodeParameters(def.inputs as any[], argsHex)
+        inputs = (def.inputs || []).map((inp, i) => ({
+            name: inp.name || `arg${i}`,
+            type: inp.type,
+            value: decodedInputs[i]
+        }))
+    } catch { /* leave empty */ }
+
+    let outputs: DecodedFrameCall['outputs'] = null
+    if (outputData && outputData !== '0x' && def.outputs && def.outputs.length > 0) {
+        try {
+            const decodedOutputs = abi.decodeParameters(def.outputs as any[], outputData)
+            outputs = def.outputs.map((out, i) => ({
+                name: out.name || '',
+                type: out.type,
+                value: decodedOutputs[i]
+            }))
+        } catch { /* leave null */ }
+    }
+
+    return {
+        fnName: def.name,
+        canonicalName: fnObj.canonicalName,
+        contract: {
+            name: contractEntry.name || '(unnamed)',
+            address: contractEntry.address
+        },
+        inputs,
+        outputs
+    }
+}
+
+export function decodeLog(
+    contracts: Entities.Contract[],
+    log: { address: string; topics: string[]; data: string }
+): DecodedLog | null {
+    if (!log.topics || log.topics.length === 0) return null
+    const topic0 = log.topics[0].toLowerCase()
+
+    let chosen: { item: AbiItem; ev: abi.Event; contract: Entities.Contract } | null = null
+
+    const target = findContractByAddress(contracts, log.address)
+
+    const search = (c: Entities.Contract) => {
+        const items = asArray(c.abi)
+        for (const item of items) {
+            if (item.type !== 'event' || item.anonymous) continue
+            try {
+                const ev = new abi.Event(item as abi.Event.Definition)
+                if (ev.signature.toLowerCase() === topic0) {
+                    chosen = { item, ev, contract: c }
+                    return true
+                }
+            } catch {
+                // skip
+            }
+        }
+        return false
+    }
+
+    if (target && search(target)) {
+        // matched on the emitting contract
+    } else {
+        for (const c of contracts) {
+            if (search(c)) break
+        }
+    }
+    if (!chosen) return null
+
+    const def = (chosen as any).item as abi.Event.Definition
+    const evObj = (chosen as any).ev as abi.Event
+    const contractEntry = (chosen as any).contract as Entities.Contract
+
+    try {
+        const decoded = evObj.decode(log.data, log.topics)
+        const args = (def.inputs || []).map((inp, i) => ({
+            name: inp.name || `arg${i}`,
+            type: inp.type,
+            indexed: !!inp.indexed,
+            value: decoded[i]
+        }))
+        return {
+            canonicalName: evObj.canonicalName,
+            eventName: def.name,
+            args,
+            contract: {
+                name: contractEntry.name || '(unnamed)',
+                address: contractEntry.address
+            }
+        }
+    } catch {
+        return null
+    }
+}
+
+export function lookupBySelector(
+    contracts: Entities.Contract[],
+    selector: string
+): FunctionHit[] {
+    const needle = selector.toLowerCase()
+    const hits: FunctionHit[] = []
+    for (const c of contracts) {
+        const items = asArray(c.abi)
+        for (const item of items) {
+            if (item.type !== 'function') continue
+            try {
+                const fn = new abi.Function(item as abi.Function.Definition)
+                if (fn.signature.toLowerCase() === needle) {
+                    hits.push({
+                        kind: 'function',
+                        selector: fn.signature.toLowerCase(),
+                        canonicalName: fn.canonicalName,
+                        definition: item as abi.Function.Definition,
+                        contract: { name: c.name || '(unnamed)', address: c.address }
+                    })
+                }
+            } catch {
+                // Malformed function in this ABI — skip.
+            }
+        }
+    }
+    return hits
+}

--- a/src/utils/input-classifier.ts
+++ b/src/utils/input-classifier.ts
@@ -1,0 +1,66 @@
+// Classifies a raw user-supplied string for the Debugger page.
+//
+// Sync stage detects shape only. A 32-byte 0x string is ambiguous between
+// a tx hash and a topic0 — callers should run `resolveTxOrTopic0` against
+// the current Connex instance to disambiguate.
+
+export type DebuggerInputKind =
+  | 'tx_or_topic0'
+  | 'selector'
+  | 'address'
+  | 'calldata'
+  | 'tx'
+  | 'topic0'
+  | 'unknown'
+
+export interface ClassifiedInput {
+  kind: DebuggerInputKind
+  value: string
+}
+
+const HEX_PREFIX = /^0x/i
+
+function isHexString(input: string): boolean {
+  if (!HEX_PREFIX.test(input)) return false
+  return /^0x[0-9a-fA-F]*$/.test(input)
+}
+
+export function normalize(input: string): string {
+  return input.trim()
+}
+
+export function classify(raw: string): ClassifiedInput {
+  const value = normalize(raw)
+  if (!value) return { kind: 'unknown', value }
+  if (!isHexString(value)) return { kind: 'unknown', value }
+
+  const hexLen = value.length - 2
+
+  if (hexLen === 64) {
+    return { kind: 'tx_or_topic0', value: value.toLowerCase() }
+  }
+  if (hexLen === 40) {
+    return { kind: 'address', value: value.toLowerCase() }
+  }
+  if (hexLen === 8) {
+    return { kind: 'selector', value: value.toLowerCase() }
+  }
+  if (hexLen > 8 && hexLen % 2 === 0) {
+    return { kind: 'calldata', value: value.toLowerCase() }
+  }
+  return { kind: 'unknown', value }
+}
+
+// Disambiguates a 32-byte hex string by checking whether it corresponds to
+// an actual transaction on the connected node. Falls back to topic0 otherwise.
+export async function resolveTxOrTopic0(
+  connex: Connex,
+  value: string
+): Promise<'tx' | 'topic0'> {
+  try {
+    const tx = await connex.thor.transaction(value).get()
+    return tx ? 'tx' : 'topic0'
+  } catch {
+    return 'topic0'
+  }
+}

--- a/src/views/Debugger.vue
+++ b/src/views/Debugger.vue
@@ -1,5 +1,43 @@
 <template>
     <section class="debugger-layout">
+        <!-- Tab bar: each submitted search becomes its own tab so users can
+             pivot to inspect something else without losing prior state. -->
+        <div v-if="tabs.length" class="tab-bar">
+            <div
+                v-for="tab in tabs"
+                :key="tab.id"
+                class="tab"
+                :class="{ 'is-active': tab.id === activeTabId }"
+                @click="selectTab(tab.id)"
+                :title="tab.value"
+            >
+                <span class="tab-kind">{{ kindLabel(tab.kind) }}</span>
+                <input
+                    v-if="editingTabId === tab.id"
+                    ref="renameInput"
+                    v-model="editingValue"
+                    class="tab-rename"
+                    @keyup.enter="commitRename(tab)"
+                    @keyup.esc="cancelRename"
+                    @blur="commitRename(tab)"
+                    @click.stop
+                    @dblclick.stop
+                />
+                <span
+                    v-else
+                    class="tab-label"
+                    @dblclick.stop="startRename(tab)"
+                    title="Double-click to rename"
+                >{{ tab.label }}</span>
+                <button
+                    type="button"
+                    class="tab-close"
+                    @click.stop="closeTab(tab.id)"
+                    aria-label="Close tab"
+                >×</button>
+            </div>
+        </div>
+
         <div class="debugger-input-bar">
             <b-field class="input-field" expanded>
                 <b-input
@@ -19,22 +57,14 @@
             >
                 Inspect
             </button>
-            <button
-                v-if="active"
-                type="button"
-                class="button is-light"
-                @click="onClear"
-            >
-                Clear
-            </button>
         </div>
 
         <div class="debugger-content">
-            <div v-if="!active && !resolving && !errorMsg" class="empty-state">
+            <div v-if="!tabs.length && !resolving && !errorMsg" class="empty-state">
                 <b-icon icon="search-plus" size="is-large" custom-class="has-text-grey-light"></b-icon>
                 <p class="empty-title">Inspect anything on-chain</p>
                 <p class="empty-desc">
-                    Paste one of the following to investigate it:
+                    Paste one of the following to investigate it — each search opens in its own tab:
                 </p>
                 <ul class="accepted-list">
                     <li><strong>Transaction hash</strong> — full forensics (clauses, events, revert reason)</li>
@@ -50,17 +80,28 @@
                 <p class="error-text">{{ errorMsg }}</p>
             </div>
 
-            <TxForensicsPanel v-if="active && active.kind === 'tx'" :value="active.value" />
-            <Topic0LookupPanel v-else-if="active && active.kind === 'topic0'" :value="active.value" />
-            <SelectorLookupPanel v-else-if="active && active.kind === 'selector'" :value="active.value" />
-            <CalldataDecoderPanel v-else-if="active && active.kind === 'calldata'" :value="active.value" />
-            <AddressInspectorPanel v-else-if="active && active.kind === 'address'" :value="active.value" />
+            <!-- Render every tab's panel and toggle visibility via v-show, so
+                 inactive panels stay mounted and preserve their state (loaded
+                 receipts, decoded args, traces, Sourcify/b32 enrichments). -->
+            <template v-for="tab in tabs">
+                <div
+                    :key="tab.id"
+                    v-show="tab.id === activeTabId"
+                    class="tab-panel"
+                >
+                    <TxForensicsPanel v-if="tab.kind === 'tx'" :value="tab.value" />
+                    <Topic0LookupPanel v-else-if="tab.kind === 'topic0'" :value="tab.value" />
+                    <SelectorLookupPanel v-else-if="tab.kind === 'selector'" :value="tab.value" />
+                    <CalldataDecoderPanel v-else-if="tab.kind === 'calldata'" :value="tab.value" />
+                    <AddressInspectorPanel v-else-if="tab.kind === 'address'" :value="tab.value" />
+                </div>
+            </template>
         </div>
     </section>
 </template>
 
 <script lang="ts">
-import { Vue, Component } from 'vue-property-decorator'
+import { Vue, Component, Watch } from 'vue-property-decorator'
 import { classify, resolveTxOrTopic0, ClassifiedInput, DebuggerInputKind } from '../utils/input-classifier'
 import TxForensicsPanel from '../components/Debugger/TxForensicsPanel.vue'
 import SelectorLookupPanel from '../components/Debugger/SelectorLookupPanel.vue'
@@ -70,9 +111,73 @@ import AddressInspectorPanel from '../components/Debugger/AddressInspectorPanel.
 
 type ResolvedKind = Exclude<DebuggerInputKind, 'tx_or_topic0' | 'unknown'>
 
-interface ActiveInput {
+interface DebuggerTab {
+    id: string
     kind: ResolvedKind
     value: string
+    label: string
+}
+
+let _tabCounter = 0
+function nextTabId(): string {
+    _tabCounter += 1
+    return `t${Date.now().toString(36)}${_tabCounter}`
+}
+
+// localStorage key for the Debugger's tab list + active tab. Refreshing the
+// page rebuilds the JS context (keep-alive only protects same-session route
+// changes), so we serialize the slim state here and restore on mount. Per-tab
+// panel state (loaded receipts, traces, etc.) is re-fetched on remount — the
+// b32 / Sourcify / OpenChain Dexie caches keep that fast.
+//
+// Keyed by genesis ID so each network (main / test / solo / custom) keeps an
+// independent tab set. Otherwise testnet would inherit mainnet hashes that
+// don't resolve, and vice versa.
+const STORAGE_KEY_BASE = 'debugger-tabs-v1'
+
+function storageKey(genesisId: string): string {
+    return `${STORAGE_KEY_BASE}:${genesisId}`
+}
+
+interface PersistedState {
+    tabs: DebuggerTab[]
+    activeTabId: string | null
+}
+
+function loadPersisted(genesisId: string): PersistedState | null {
+    try {
+        const raw = localStorage.getItem(storageKey(genesisId))
+        if (!raw) return null
+        const parsed = JSON.parse(raw)
+        if (!parsed || !Array.isArray(parsed.tabs)) return null
+        return parsed as PersistedState
+    } catch {
+        return null
+    }
+}
+
+function savePersisted(genesisId: string, state: PersistedState) {
+    try {
+        localStorage.setItem(storageKey(genesisId), JSON.stringify(state))
+    } catch {
+        // quota exceeded or storage disabled — ignore
+    }
+}
+
+function shortHex(v: string, head = 8, tail = 4): string {
+    if (!v) return ''
+    if (v.length <= head + tail + 2) return v
+    return v.slice(0, 2 + head) + '…' + v.slice(-tail)
+}
+
+function makeLabel(kind: ResolvedKind, value: string): string {
+    switch (kind) {
+        case 'tx':       return shortHex(value, 8, 4)
+        case 'topic0':   return shortHex(value, 8, 4)
+        case 'selector': return value
+        case 'calldata': return shortHex(value, 6, 4)
+        case 'address':  return shortHex(value, 6, 4)
+    }
 }
 
 @Component({
@@ -87,12 +192,92 @@ interface ActiveInput {
 })
 export default class Debugger extends Vue {
     private rawInput: string = ''
-    private active: ActiveInput | null = null
+    private tabs: DebuggerTab[] = []
+    private activeTabId: string | null = null
     private resolving: boolean = false
     private errorMsg: string = ''
+    private editingTabId: string | null = null
+    private editingValue: string = ''
+    private restored: boolean = false
+
+    private created() {
+        const state = loadPersisted(this.$connex.thor.genesis.id)
+        if (!state) {
+            this.restored = true
+            return
+        }
+        // Re-mint IDs on restore so they can't collide with anything new minted
+        // during this session by nextTabId(). Re-point activeTabId at the
+        // remapped value if it still exists.
+        const idMap = new Map<string, string>()
+        const restoredTabs: DebuggerTab[] = state.tabs
+            .filter((t) => t && t.kind && t.value)
+            .map((t) => {
+                const newId = nextTabId()
+                idMap.set(t.id, newId)
+                return {
+                    id: newId,
+                    kind: t.kind,
+                    value: t.value,
+                    label: t.label || makeLabel(t.kind, t.value)
+                }
+            })
+        this.tabs = restoredTabs
+        if (state.activeTabId && idMap.has(state.activeTabId)) {
+            this.activeTabId = idMap.get(state.activeTabId) || null
+        } else {
+            this.activeTabId = restoredTabs.length ? restoredTabs[restoredTabs.length - 1].id : null
+        }
+        this.restored = true
+    }
+
+    @Watch('tabs', { deep: true })
+    private onTabsChanged() {
+        if (!this.restored) return
+        savePersisted(this.$connex.thor.genesis.id, {
+            tabs: this.tabs,
+            activeTabId: this.activeTabId
+        })
+    }
+
+    @Watch('activeTabId')
+    private onActiveTabIdChanged() {
+        if (!this.restored) return
+        savePersisted(this.$connex.thor.genesis.id, {
+            tabs: this.tabs,
+            activeTabId: this.activeTabId
+        })
+    }
 
     get canSubmit(): boolean {
         return !!this.rawInput.trim() && !this.resolving
+    }
+
+    private kindLabel(kind: ResolvedKind): string {
+        switch (kind) {
+            case 'tx':       return 'tx'
+            case 'topic0':   return 'topic0'
+            case 'selector': return 'fn'
+            case 'calldata': return 'data'
+            case 'address':  return 'addr'
+        }
+    }
+
+    private openOrFocusTab(kind: ResolvedKind, value: string) {
+        // De-dupe: if an identical tab is already open, just focus it.
+        const existing = this.tabs.find((t) => t.kind === kind && t.value === value)
+        if (existing) {
+            this.activeTabId = existing.id
+            return
+        }
+        const tab: DebuggerTab = {
+            id: nextTabId(),
+            kind,
+            value,
+            label: makeLabel(kind, value)
+        }
+        this.tabs.push(tab)
+        this.activeTabId = tab.id
     }
 
     private async onSubmit() {
@@ -101,7 +286,6 @@ export default class Debugger extends Vue {
         const classified: ClassifiedInput = classify(this.rawInput)
 
         if (classified.kind === 'unknown') {
-            this.active = null
             this.errorMsg = 'Unrecognized input. Expected a 0x-prefixed hex value.'
             return
         }
@@ -110,23 +294,68 @@ export default class Debugger extends Vue {
             this.resolving = true
             try {
                 const resolved = await resolveTxOrTopic0(this.$connex, classified.value)
-                this.active = { kind: resolved, value: classified.value }
+                this.openOrFocusTab(resolved, classified.value)
+                this.rawInput = ''
             } catch (e: any) {
                 this.errorMsg = e && e.message ? e.message : 'Failed to resolve input.'
-                this.active = null
             } finally {
                 this.resolving = false
             }
             return
         }
 
-        this.active = { kind: classified.kind as ResolvedKind, value: classified.value }
+        this.openOrFocusTab(classified.kind as ResolvedKind, classified.value)
+        this.rawInput = ''
     }
 
-    private onClear() {
-        this.rawInput = ''
-        this.active = null
+    private selectTab(id: string) {
+        this.activeTabId = id
         this.errorMsg = ''
+    }
+
+    private closeTab(id: string) {
+        const idx = this.tabs.findIndex((t) => t.id === id)
+        if (idx === -1) return
+        this.tabs.splice(idx, 1)
+        if (this.activeTabId === id) {
+            const next = this.tabs[idx] || this.tabs[idx - 1] || null
+            this.activeTabId = next ? next.id : null
+        }
+        if (this.editingTabId === id) {
+            this.editingTabId = null
+        }
+    }
+
+    private startRename(tab: DebuggerTab) {
+        this.editingTabId = tab.id
+        this.editingValue = tab.label
+        this.$nextTick(() => {
+            const refs = this.$refs.renameInput as any
+            const el = Array.isArray(refs) ? refs[0] : refs
+            if (el && typeof el.focus === 'function') {
+                el.focus()
+                if (typeof el.select === 'function') el.select()
+            }
+        })
+    }
+
+    private commitRename(tab: DebuggerTab) {
+        if (this.editingTabId !== tab.id) return
+        const trimmed = this.editingValue.trim()
+        // Empty input resets to the auto-generated label, so users can revert
+        // to the default by clearing.
+        const idx = this.tabs.findIndex((t) => t.id === tab.id)
+        if (idx !== -1) {
+            this.$set(this.tabs, idx, {
+                ...this.tabs[idx],
+                label: trimmed || makeLabel(tab.kind, tab.value)
+            })
+        }
+        this.editingTabId = null
+    }
+
+    private cancelRename() {
+        this.editingTabId = null
     }
 }
 </script>
@@ -137,6 +366,113 @@ export default class Debugger extends Vue {
     flex-direction: column;
     height: 100%;
     background: var(--body-background-alt);
+}
+
+.tab-bar {
+    display: flex;
+    align-items: stretch;
+    gap: 0.25rem;
+    padding: 0.4rem 1rem 0;
+    background: var(--card-background);
+    border-bottom: 1px solid var(--border-color);
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.55rem 0.4rem 0.7rem;
+    background: var(--code-bg);
+    border: 1px solid var(--border-color);
+    border-bottom: none;
+    border-radius: 6px 6px 0 0;
+    cursor: pointer;
+    font-size: 0.78rem;
+    color: var(--text-color-light);
+    user-select: none;
+    transition: background 0.15s ease, color 0.15s ease;
+    flex-shrink: 0;
+    max-width: 240px;
+    min-width: 0;
+    position: relative;
+    top: 1px;
+}
+.tab:hover {
+    background: var(--hover-bg);
+    color: var(--text-color);
+}
+.tab.is-active {
+    background: var(--body-background-alt);
+    color: var(--text-color);
+    border-color: var(--border-color);
+    border-bottom: 1px solid var(--body-background-alt);
+    z-index: 1;
+}
+/* Primary-coloured accent line at the top of the active tab — matches the
+   active-contract treatment in Contract.vue (border-left there). */
+.tab.is-active::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--primary-color);
+    border-radius: 6px 6px 0 0;
+}
+
+.tab-kind {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    background: rgba(50, 115, 220, 0.18);
+    color: var(--primary-color);
+    flex-shrink: 0;
+}
+
+.tab-label {
+    font-family: monospace;
+    font-size: 0.78rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    cursor: text;
+}
+
+.tab-rename {
+    font-family: monospace;
+    font-size: 0.78rem;
+    background: var(--card-background);
+    color: var(--text-color);
+    border: 1px solid var(--primary-color);
+    border-radius: 3px;
+    padding: 0.05rem 0.3rem;
+    min-width: 0;
+    width: 12ch;
+    outline: none;
+}
+
+.tab-close {
+    background: transparent;
+    border: none;
+    color: var(--text-color-light);
+    cursor: pointer;
+    font-size: 1.05rem;
+    line-height: 1;
+    padding: 0 0.15rem;
+    border-radius: 3px;
+    flex-shrink: 0;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+.tab-close:hover {
+    background: var(--hover-bg);
+    color: var(--text-color);
 }
 
 .debugger-input-bar {
@@ -156,6 +492,11 @@ export default class Debugger extends Vue {
 .debugger-content {
     flex: 1;
     overflow-y: auto;
+    position: relative;
+}
+
+.tab-panel {
+    /* Inactive tabs are hidden with v-show=false so they keep their state. */
 }
 
 .empty-state {

--- a/src/views/Debugger.vue
+++ b/src/views/Debugger.vue
@@ -1,0 +1,215 @@
+<template>
+    <section class="debugger-layout">
+        <div class="debugger-input-bar">
+            <b-field class="input-field" expanded>
+                <b-input
+                    v-model="rawInput"
+                    placeholder="Paste a tx hash, calldata, 4-byte selector, topic0, or address (0x…)"
+                    icon="search"
+                    @keyup.native.enter="onSubmit"
+                    expanded
+                />
+            </b-field>
+            <button
+                type="button"
+                class="button is-primary"
+                :disabled="!canSubmit"
+                :class="{ 'is-loading': resolving }"
+                @click="onSubmit"
+            >
+                Inspect
+            </button>
+            <button
+                v-if="active"
+                type="button"
+                class="button is-light"
+                @click="onClear"
+            >
+                Clear
+            </button>
+        </div>
+
+        <div class="debugger-content">
+            <div v-if="!active && !resolving && !errorMsg" class="empty-state">
+                <b-icon icon="search-plus" size="is-large" custom-class="has-text-grey-light"></b-icon>
+                <p class="empty-title">Inspect anything on-chain</p>
+                <p class="empty-desc">
+                    Paste one of the following to investigate it:
+                </p>
+                <ul class="accepted-list">
+                    <li><strong>Transaction hash</strong> — full forensics (clauses, events, revert reason)</li>
+                    <li><strong>Calldata</strong> — decode against your imported ABIs</li>
+                    <li><strong>4-byte selector</strong> — find the matching function</li>
+                    <li><strong>Event topic0</strong> — find the matching event</li>
+                    <li><strong>Address</strong> — bytecode, proxy detection, ERC sniff</li>
+                </ul>
+            </div>
+
+            <div v-if="errorMsg" class="error-state">
+                <b-icon icon="exclamation-triangle" size="is-medium" custom-class="has-text-warning"></b-icon>
+                <p class="error-text">{{ errorMsg }}</p>
+            </div>
+
+            <TxForensicsPanel v-if="active && active.kind === 'tx'" :value="active.value" />
+            <Topic0LookupPanel v-else-if="active && active.kind === 'topic0'" :value="active.value" />
+            <SelectorLookupPanel v-else-if="active && active.kind === 'selector'" :value="active.value" />
+            <CalldataDecoderPanel v-else-if="active && active.kind === 'calldata'" :value="active.value" />
+            <AddressInspectorPanel v-else-if="active && active.kind === 'address'" :value="active.value" />
+        </div>
+    </section>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator'
+import { classify, resolveTxOrTopic0, ClassifiedInput, DebuggerInputKind } from '../utils/input-classifier'
+import TxForensicsPanel from '../components/Debugger/TxForensicsPanel.vue'
+import SelectorLookupPanel from '../components/Debugger/SelectorLookupPanel.vue'
+import Topic0LookupPanel from '../components/Debugger/Topic0LookupPanel.vue'
+import CalldataDecoderPanel from '../components/Debugger/CalldataDecoderPanel.vue'
+import AddressInspectorPanel from '../components/Debugger/AddressInspectorPanel.vue'
+
+type ResolvedKind = Exclude<DebuggerInputKind, 'tx_or_topic0' | 'unknown'>
+
+interface ActiveInput {
+    kind: ResolvedKind
+    value: string
+}
+
+@Component({
+    name: 'Debugger',
+    components: {
+        TxForensicsPanel,
+        SelectorLookupPanel,
+        Topic0LookupPanel,
+        CalldataDecoderPanel,
+        AddressInspectorPanel
+    }
+})
+export default class Debugger extends Vue {
+    private rawInput: string = ''
+    private active: ActiveInput | null = null
+    private resolving: boolean = false
+    private errorMsg: string = ''
+
+    get canSubmit(): boolean {
+        return !!this.rawInput.trim() && !this.resolving
+    }
+
+    private async onSubmit() {
+        if (!this.canSubmit) return
+        this.errorMsg = ''
+        const classified: ClassifiedInput = classify(this.rawInput)
+
+        if (classified.kind === 'unknown') {
+            this.active = null
+            this.errorMsg = 'Unrecognized input. Expected a 0x-prefixed hex value.'
+            return
+        }
+
+        if (classified.kind === 'tx_or_topic0') {
+            this.resolving = true
+            try {
+                const resolved = await resolveTxOrTopic0(this.$connex, classified.value)
+                this.active = { kind: resolved, value: classified.value }
+            } catch (e: any) {
+                this.errorMsg = e && e.message ? e.message : 'Failed to resolve input.'
+                this.active = null
+            } finally {
+                this.resolving = false
+            }
+            return
+        }
+
+        this.active = { kind: classified.kind as ResolvedKind, value: classified.value }
+    }
+
+    private onClear() {
+        this.rawInput = ''
+        this.active = null
+        this.errorMsg = ''
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.debugger-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: var(--body-background-alt);
+}
+
+.debugger-input-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    background: var(--card-background);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.input-field {
+    flex: 1;
+    margin-bottom: 0 !important;
+}
+
+.debugger-content {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.empty-state {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 2rem;
+    text-align: center;
+}
+
+.empty-title {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin: 0.5rem 0 0.25rem;
+}
+
+.empty-desc {
+    color: var(--text-color-light);
+    margin-bottom: 0.5rem;
+}
+
+.accepted-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    text-align: left;
+    color: var(--text-color-light);
+    font-size: 0.9rem;
+    line-height: 1.8;
+}
+
+.accepted-list strong {
+    color: var(--text-color);
+    font-weight: 600;
+}
+
+.error-state {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 1rem;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 165, 32, 0.1);
+    border: 1px solid rgba(255, 165, 32, 0.3);
+    border-radius: 6px;
+    color: var(--text-color);
+}
+
+.error-text {
+    margin: 0;
+    font-size: 0.9rem;
+}
+</style>


### PR DESCRIPTION
## Summary

Adds a new **Debugger** page at `/debugger` that turns the Inspector into a real on-chain investigation tool. Paste any `0x`-prefixed value (tx hash, calldata, 4-byte selector, topic0, or address), and the page routes it to the right inspector. Searches open as **tabs** so you can pivot between investigations without losing state.

### What you can do
- **Tx forensics** — receipt header, per-clause decoded calls, decoded events, revert-reason resolution, and an internal call trace (Tenderly-style indented tree with type chips, decoded inline calls, hover-revealed click-to-copy addresses, gas column, and expand/collapse).
- **Revert decoding** — prefers `/debug/tracers` (real on-chain state at the failing block) and falls back to `inspectClauses` at `blockNumber - 1`. Handles `Error(string)`, `Panic(uint256)` with code descriptions, custom errors (decoded against imported error ABIs), and EVM-level halts like `out of gas` via deep-frame walk.
- **Address inspector** — balances, bytecode size, ERC-20 / ERC-721 selector sniff, EIP-1967 proxy slot reads (impl / admin / beacon), likely-library detection, ABI viewer (pretty-printed JSON with copy), and **"Add to my contracts"** wired into the existing `EditContract` modal with the form pre-filled.
- **Lookup panels** — standalone Selector / Topic0 / Calldata decode against the merged registry.
- **Tabs** — every search opens its own tab. Double-click to rename, × to close. Active tab gets a primary-coloured accent line matching `Contract.vue`'s `is-active` treatment. Tabs persist across reloads via `localStorage`, **keyed per-genesis-id** so each network keeps its own set.
- **Network switch** keeps you on the current route instead of redirecting to `/contracts`.

### Decoding pipeline
Four progressively-broader sources, each cached in IndexedDB so subsequent lookups are instant:
1. **Local registry** — user-imported contracts + b32 built-ins (`AllBuiltInContracts`).
2. **Sourcify** — per address, proxy-aware via EIP-1967 impl resolution. Persisted in a new `sourcedAbis` Dexie table.
3. **b32 keccak DB** — full ABI items keyed by 4-byte selector or 32-byte topic0. Persisted in `b32Signatures` with negative caching.
4. **OpenChain cross-chain signature DB** — canonical signatures from Ethereum and other EVM chains, useful for VeChain forks of Uniswap/Aave/etc. Persisted in `openchainSignatures`. Batched per request (one HTTP call for up to 50 selectors).

Tx forensics and the internal trace each run their own enrichment passes after load — clause targets + event emitters via Sourcify, leftover selectors + topic0s via b32 → OpenChain — then commit reactively in a single shot so all rows decode together rather than flickering in one by one.


https://github.com/user-attachments/assets/6815c857-2198-4c73-b098-be3d1425e2f4



