### PR TITLE
feat: use explore.vechain.org as the block explorer

### DIFF
--- a/src/components/Contract.vue
+++ b/src/components/Contract.vue
@@ -80,7 +80,7 @@
                     <p class="is-family-monospace has-text-weight-semibold display-6" v-else>
                         <a
                             target="_blank"
-                            :href="`${$explorerAccount}${item.address}`"
+                            :href="$explorerAccount(item.address)"
                         >{{item.address | toChecksumAddress}}</a>
                     </p>
                 </div>

--- a/src/components/Debugger/AddressInspectorPanel.vue
+++ b/src/components/Debugger/AddressInspectorPanel.vue
@@ -21,7 +21,7 @@
                             <b-icon icon="question-circle" size="is-small"></b-icon>
                         </button>
                     </span>
-                    <a :href="$explorerAccount + value" target="_blank" rel="noopener" class="external-link">
+                    <a :href="$explorerAccount(value)" target="_blank" rel="noopener" class="external-link">
                         View on explorer
                         <b-icon icon="external-link-alt" size="is-small"></b-icon>
                     </a>

--- a/src/components/Debugger/TxForensicsPanel.vue
+++ b/src/components/Debugger/TxForensicsPanel.vue
@@ -24,7 +24,7 @@
                             {{ receipt.reverted ? 'Reverted' : 'Success' }}
                         </span>
                     </div>
-                    <a :href="$explorerTx + tx.id" target="_blank" rel="noopener" class="external-link">
+                    <a :href="$explorerTx(tx.id)" target="_blank" rel="noopener" class="external-link">
                         View on explorer
                         <b-icon icon="external-link-alt" size="is-small"></b-icon>
                     </a>

--- a/src/components/Deploy/DeploySuccessCard.vue
+++ b/src/components/Deploy/DeploySuccessCard.vue
@@ -87,7 +87,7 @@ export default class DeploySuccessCard extends Vue {
     saved = false
 
     get txExplorerUrl(): string {
-        return `${(this as any).$explorerTx}${this.txid}`
+        return (this as any).$explorerTx(this.txid)
     }
 
     get filteredCategories(): string[] {

--- a/src/components/EventShowCard.vue
+++ b/src/components/EventShowCard.vue
@@ -18,7 +18,7 @@
                         #Block
                         <a
                             target="_blank"
-                            :href="`${$explorerBlock}${item.meta.blockID}`"
+                            :href="$explorerBlock(item.meta.blockID)"
                         >{{item.meta.blockNumber}}</a>
                     </span>
                     <span
@@ -30,7 +30,7 @@
                     <a
                         class="is-family-monospace display-6 has-text-weight-semibold"
                         target="_blank"
-                        :href="`${$explorerTx}${item.meta.txID}`"
+                        :href="$explorerTx(item.meta.txID)"
                     >{{item.meta.txID | addr}}</a>
                 </div>
             </div>
@@ -63,7 +63,7 @@
                                     v-if="props.row.type === 'address'"
                                     target="_blank"
                                     class="has-text-weight-semibold is-family-monospace display-6"
-                                    :href="`${$explorerAccount}${props.row.value}`"
+                                    :href="$explorerAccount(props.row.value)"
                                 >{{ props.row.value | toChecksumAddress}}</a>
                                 <span
                                     v-else

--- a/src/components/FunctionCard.vue
+++ b/src/components/FunctionCard.vue
@@ -223,7 +223,7 @@ export default class FunctionCard extends Mixins(AccountCall) {
         
         if (this.txid) {
             output += `Transaction ID: ${this.txid}\n`
-            output += `Explorer: ${this.$explorerTx}${this.txid}\n\n`
+            output += `Explorer: ${this.$explorerTx(this.txid)}\n\n`
         }
         
         if (this.receipt) {

--- a/src/components/RoleActivityList.vue
+++ b/src/components/RoleActivityList.vue
@@ -26,14 +26,14 @@
         </span>
         <span class="event-text">to</span>
         <a
-          :href="`${$explorerAccount}${event.account}`"
+          :href="$explorerAccount(event.account)"
           target="_blank"
           class="address-link"
           :title="event.account"
         >{{ event.account | addr }}</a>
         <span class="event-text">by</span>
         <a
-          :href="`${$explorerAccount}${event.sender}`"
+          :href="$explorerAccount(event.sender)"
           target="_blank"
           class="address-link"
           :title="event.sender"
@@ -44,7 +44,7 @@
           :title="formatFullDate(event.timestamp)"
         >{{ formatRelativeTime(event.timestamp) }}</span>
         <a
-          :href="`${$explorerTx}${event.txId}`"
+          :href="$explorerTx(event.txId)"
           target="_blank"
           class="tx-link"
           title="View transaction"

--- a/src/components/RoleCard.vue
+++ b/src/components/RoleCard.vue
@@ -29,7 +29,7 @@
         <div class="holders-list">
           <div v-for="(holder, index) in holders" :key="index" class="holder-item">
             <a
-              :href="`${$explorerAccount}${holder}`"
+              :href="$explorerAccount(holder)"
               target="_blank"
               class="holder-address-link"
               @click.stop

--- a/src/components/SampleFuncCard.vue
+++ b/src/components/SampleFuncCard.vue
@@ -117,7 +117,7 @@ export default class SampleFuncCard extends Mixins(AccountCall) {
         
         if (this.txid) {
             output += `Transaction ID: ${this.txid}\n`
-            output += `Explorer: ${this.$explorerTx}${this.txid}\n\n`
+            output += `Explorer: ${this.$explorerTx(this.txid)}\n\n`
         }
         
         if (this.receipt) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,9 +20,9 @@ import { isCustomNetwork, getCustomNetworkId } from './utils'
 declare module 'vue/types/vue' {
   interface Vue {
     $connex: Connex
-    $explorerAccount: string
-    $explorerBlock: string
-    $explorerTx: string
+    $explorerAccount: (id: string) => string
+    $explorerBlock: (id: string) => string
+    $explorerTx: (id: string) => string
     $nodeUrl: string
   }
 }
@@ -44,11 +44,25 @@ Vue.use(VueAnalytics, {
 Vue.config.productionTip = false
 
 
-function setExplorerUrl(path: string) {
-  const temp = path ? (path + '/') : path
-  Vue.prototype.$explorerAccount = `https://insight.vecha.in/#/${temp}accounts/`
-  Vue.prototype.$explorerBlock = `https://insight.vecha.in/#/${temp}blocks/`
-  Vue.prototype.$explorerTx = `https://insight.vecha.in/#/${temp}txs/`
+function setExplorerUrl(path: 'main' | 'test' | 'solo') {
+  if (path === 'solo') {
+    Vue.prototype.$explorerAccount = (id: string) => `https://insight.vecha.in/#/solo/accounts/${id}`
+    Vue.prototype.$explorerBlock = (id: string) => `https://insight.vecha.in/#/solo/blocks/${id}`
+    Vue.prototype.$explorerTx = (id: string) => `https://insight.vecha.in/#/solo/txs/${id}`
+    return
+  }
+  const network = path === 'main' ? 'mainnet' : 'testnet'
+  const query = `?network=${network}`
+  Vue.prototype.$explorerAccount = (id: string) => `https://explore.vechain.org/address/${id}${query}`
+  Vue.prototype.$explorerBlock = (id: string) => `https://explore.vechain.org/block/${id}${query}`
+  Vue.prototype.$explorerTx = (id: string) => `https://explore.vechain.org/transactions/${id}${query}`
+}
+
+function setExplorerUrlForCustomNode(nodeUrl: string) {
+  const host = nodeUrl.endsWith('/') ? nodeUrl : (nodeUrl + '/')
+  Vue.prototype.$explorerAccount = (id: string) => `${host}accounts/${id}`
+  Vue.prototype.$explorerBlock = (id: string) => `${host}blocks/${id}`
+  Vue.prototype.$explorerTx = (id: string) => `${host}transactions/${id}`
 }
 
 async function initApp() {
@@ -58,7 +72,7 @@ async function initApp() {
   console.log("net", net)
 
   if (['test', 'main', 'solo'].includes(net)) {
-    setExplorerUrl(net)
+    setExplorerUrl(net as "test" | "main" | "solo")
     Vue.prototype.$connex = createConnex(net as "test" | "main" | "solo")
     Vue.prototype.$nodeUrl = nodeUrls[net as "test" | "main" | "solo"]
   } else if (isCustomNetwork(net)) {
@@ -86,10 +100,7 @@ async function initApp() {
               transactions: []
             }
 
-            const host = customNetwork.nodeUrl.endsWith('/') ? customNetwork.nodeUrl : (customNetwork.nodeUrl + '/')
-            Vue.prototype.$explorerAccount = `${host}accounts/`
-            Vue.prototype.$explorerBlock = `${host}blocks/`
-            Vue.prototype.$explorerTx = `${host}transactions/`
+            setExplorerUrlForCustomNode(customNetwork.nodeUrl)
 
             Vue.prototype.$connex = createConnexForNetwork(customNetwork.nodeUrl, genesisBlock, genesisBlock.id)
             Vue.prototype.$nodeUrl = customNetwork.nodeUrl
@@ -120,10 +131,7 @@ async function initApp() {
           // main
           setExplorerUrl('main')
         } else {
-          const host = node.endsWith('/') ? node : (node + '/')
-          Vue.prototype.$explorerAccount = `${host}accounts/`
-          Vue.prototype.$explorerBlock = `${host}blocks/`
-          Vue.prototype.$explorerTx = `${host}transactions/`
+          setExplorerUrlForCustomNode(node)
         }
         Vue.prototype.$connex = createConnexForNetwork(node, network, network.id)
         Vue.prototype.$nodeUrl = node

--- a/src/views/TxBuilder.vue
+++ b/src/views/TxBuilder.vue
@@ -105,7 +105,7 @@
                         </span>
                         <a
                             v-if="submission.txid"
-                            :href="$explorerTx + submission.txid"
+                            :href="$explorerTx(submission.txid)"
                             target="_blank"
                             rel="noopener"
                             class="submission-link"


### PR DESCRIPTION
## Summary
- Switch external explorer links from `insight.vecha.in` to `explore.vechain.org` for mainnet/testnet
- New URL pattern: `/address/{id}`, `/transactions/{id}`, `/block/{id}`, all with `?network=mainnet|testnet`
- Solo keeps insight as fallback (explore.vechain.org has no solo network); custom networks unchanged
- Refactor `\$explorerAccount` / `\$explorerBlock` / `\$explorerTx` from string prefixes to `(id) => url` functions, because the new explorer puts the network in a query string *after* the id and the old prefix-string form no longer composes. All 14 call sites updated.

## Test plan
- [ ] Open a contract and click an address link — should land on `explore.vechain.org/address/...?network=mainnet`
- [ ] Submit a tx (Deploy / FunctionCard / TxBuilder / SampleFunc / RoleActivity) and click the explorer link
- [ ] Switch to testnet and repeat — links should include `?network=testnet`
- [ ] Switch to solo — links still go to `insight.vecha.in/#/solo/...`
- [ ] Connect a custom network — links use the custom node URL host

🤖 Generated with [Claude Code](https://claude.com/claude-code)